### PR TITLE
Enable testing on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - nightly
   - 0.4
+  - 0.5
 notifications:
   email: false
 script:


### PR DESCRIPTION
Julia v0.5 is the release, so this package clearly should be tested on it.