### PR TITLE
use PolynomialFactors when finding real_roots over Z[x], Q[x]; close #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,23 @@ specializations:
 
 
 * `fzeros(f::Function)` calls `real_roots` to find the real roots of
-  the polynomial. For polynomials with integer coefficients, this can
-  be more precise. (The computation requires finding a GCD, which is
-  subject to numeric issues if non-integer coefficients are involved.)
+  the polynomial. For polynomials with integer coefficients, the
+  rational roots are found first, and then numeric approximations to
+  the remaining real roots are returned.
 
-* The `factor` function will return a dictionary of roots and their
-  multiplicities. For polynomials with integer coefficients, all
-  potential rational roots will be checked and then the reduced
-  polynomial will be passed to `multroot`. Otherwise, `multroot` is
-  used directly.  The `roots` function from the `Polynomials` package
-  will find all the roots of a polynomial. Its performance degrades
-  when the polynomial has high multiplicities. The `multroot` function
-  is provided to handle this case a bit better.  The function follows
-  algorithms due to Zeng,
+* For polynomial functions over the integers or rational numbers, the
+`factor` function will return a dictionary of factors (as
+`Polynomials`) and their multiplicities.
+
+* For polynomials over the real numbers, the `multroot` function will
+  return the roots and their multiplicities through a dictionary. The
+  `roots` function from the `Polynomials` package will find all the
+  roots of a polynomial. Its performance degrades when the polynomial
+  has high multiplicities. The `multroot` function is provided to
+  handle this case a bit better.  The function follows algorithms due
+  to Zeng,
   ["Computing multiple roots of inexact polynomials", Math. Comp. 74 (2005), 869-903](http://www.ams.org/journals/mcom/2005-74-250/S0025-5718-04-01692-8/home.html).
-  This function can also be called directly via
-  `multroot(f::Function)` or `multroot(p::Poly)`.
+
 
 
 
@@ -128,7 +129,8 @@ Polynomial root finding is a bit better when multiple roots are present.
 ```
 x = poly([0.0])
 p = (x-1)^2 * (x-3)
-rts, mults = multroot(p)	# compare to roots(p)
+U = multroot(p)	
+collect(keys(U)) # compare to roots(p)
 ```
 
 Again, a polynomial function may be passed in
@@ -138,7 +140,7 @@ f(x) = (x-1)*(x-2)^2*(x-3)^3
 multroot(f)
 ```
 
-It may be more natural to use `factor` to get the roots:
+The `factor` function will factor polynomials with rational and integer coefficients over the integers:
 
 ```
 factor(f)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
-Polynomials 0.0.5
 ForwardDiff 0.2.0
-Primes
-Compat 0.4
+Polynomials 0.0.5
+Primes 0.1.1
+PolynomialFactors 0.0.2
+Compat 0.9.5

--- a/src/Polys/real_roots.jl
+++ b/src/Polys/real_roots.jl
@@ -25,28 +25,29 @@ _iszero{T <: (@compat Union{Integer, Rational})}(b::T; kwargs...) = b == 0
 _iszero{T<:AbstractFloat}(b::T; xtol=1) = abs(b) <= 2*xtol*eps(T)
 
 
-## return (q,r) with p(x) = (x-c)*q(x) + r using synthetic division
-function Base.divrem(p::Poly, c::Number)
-    ps = copy(p.a)                    # [p0, p1, ..., pn]
-    qs = eltype(p)[pop!(ps)]           # take from right
-    while length(ps) > 0
-        unshift!(qs, c*qs[1] + pop!(ps))
-    end
-    r = shift!(qs)
-    Poly(qs, p.var), r
-end
+## ## return (q,r) with p(x) = (x-c)*q(x) + r using synthetic division
+## function Base.divrem(p::Poly, c::Number)
+##     ps = copy(p.a)                    # [p0, p1, ..., pn]
+##     qs = eltype(p)[pop!(ps)]           # take from right
+##     while length(ps) > 0
+##         unshift!(qs, c*qs[1] + pop!(ps))
+##     end
+##     r = shift!(qs)
+##     Poly(qs, p.var), r
+## end
 
 ## p(x) = q(x)*(x-c)^k for some q,k (possibly 0). Return maximal k and corresponding q
 function multiplicity(p::Poly, c::Number)
     k = 0
-    q, r = divrem(p,c)
+    q, r = PolynomialFactors.synthetic_division(p,c)
     while _iszero(r)
         p = q
-        q,r = divrem(p, c)
+        q,r = PolynomialFactors.synthetic_division(p, c)
         k = k + 1
     end
     p, k
 end
+
 
 ## Our Poly types for which we can find gcd
 typealias QQ  @compat Union{Int, BigInt, Rational{Int}, Rational{BigInt}}
@@ -309,26 +310,29 @@ function real_roots_sqfree(p::Poly)
 end
 
 
-function real_roots{T <: QQ}(p::Poly{T})
-    p = convert(Poly{Rational{BigInt}}, p)
-    p = divrem(p, bgcd(p, Polynomials.polyder(p)))[1] # square free p/gcd(p, p')
-    p = p*(1//p[degree(p)])
+function real_roots{T <: Union{Rational{Int}, Rational{BigInt}}}(p::Poly{T})
+    c, q = PolynomialFactors.Qx_to_Zx(p)
+    real_roots(q)
+end
 
 
-    ## factor first
-    d = factor(p)
-    d = filter((k,v) -> isa(k, Rational), d)
-    rts = collect(keys(d))
-    for rt in rts
-        (p,k) = multiplicity(p, rt)
+function real_roots{T <: Union{Int, BigInt}}(p::Poly{T})
+    f = PolynomialFactors.square_free(p)
+    rts = Real[]
+    rat_rts = rational_roots(p)
+    append!(rts, rat_rts)
+    
+    for rt in rat_rts
+        f, k = PolynomialFactors.synthetic_division(f, rt)
     end
     
-    if degree(p) > 0
-        new_rts = real_roots_sqfree(p)
-        sort([rts; new_rts])
-    else
-        sort(rts)
+    if degree(f) > 0
+        real_rts = real_roots_sqfree(f)
+        append!(rts, real_rts)
+        sort!(rts)
     end
+
+    return rts
 end
 
 function real_roots(p::Poly)
@@ -341,75 +345,5 @@ function real_roots(p::Poly)
     real_roots_sqfree(p)
 end
 
-### Some functions to find all rational roots of a poly in Z[x], Q[x]
-## return set of divisors of |n|, e.g. 12 -> [1,2,3,4,6,12]
-function divisors(n::Integer)
-    n == 0 && return([1])
-    d = factor(abs(n))
-    out = [1]
-    for (k,v) in d
-        out = unique(out * [k^i for i in 0:v]')
-    end
-    sort(out)
-end
-
-# find rational roots of p ∈ Z[x]
-# XXX most simple-minded approach around XXX this should be improved!
-function rational_roots{T <: Integer}(p::Poly{T})
-    rts = Rational{T}[]
-    if p[0] == 0
-        push!(rts, 0)
-        p, k = multiplicity(p, 0)
-    end
-
-    ds = divisors(p[0])
-    ns = divisors(p[degree(p)])
-    poss = unique([d//n for d in ds, n in ns])
-    for rt in poss
-        for s in [-1,1]
-            prt = s * rt
-            polyval(p, prt) == 0 && push!(rts, prt)
-        end
-    end
-    rts
-end
-
-# find rational roots of p ∈ Q[x] by using lcm(p)*p ∈ Z[x]
-function rational_roots{T <: Integer}(p::Poly{Rational{T}})
-    q = lcm(map(r -> r.den, coeffs(p))) * p
-    q = convert(Poly{BigInt}, q)
-    rational_roots(q)
-end
 
 
-
-## factor over the rationals, then call multroot on the remainder
-## return d where d a dictionary of roots
-## Okay, we should use keys which are `variable(p) - r` and not `r`...
-function factor{T <: QQ}(p::Poly{T})
-    rts = rational_roots(p)
-    d = Dict{Number, Int}()
-    for r in rts
-        p,k = multiplicity(p,r)
-        d[r] = k
-    end
-    ##
-    if degree(p) > 0
-        p = convert(Poly{Float64}, p)
-        for (r,k) in zip(multroot(p)...)
-            d[r] = k
-        end
-    end
-    d
-end
-
-## Julian interface to multroot
-function factor(p::Poly)
-    degree(p) == 0 && DomainError() # degree 0
-    d = Dict{Number, Int}()
-    for (r,k) in zip(multroot(p)...)
-        d[r] = k
-    end
-    d
-end
-    

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -5,9 +5,19 @@ import Base: *
 
 using Polynomials
 import Polynomials: roots
+using PolynomialFactors
 
 using ForwardDiff
 using Compat
+
+
+if VERSION < v"0.5.0"
+    import Base: factor
+else
+    using Primes
+    import Primes: factor
+end
+
 
 export roots
 
@@ -237,30 +247,25 @@ fzeros(f::Function, a::Real, b::Real; kwargs...) = fzeros(f, [a,b]; kwargs...)
 
 
 """
-
-Factor a polynomial function.
-
-Finds factors numerically.
-
-For polynomial functions over the integers or rational tries -- as naively as possible -- to factor exactly over the rationals first.
-
-Returns a dictionary with keys that are roots and values that are multiplicities
-
+Factor a polynomial function with rational or integer coefficients over the integers.
+Returns a dictionary with irreducible factors and their multiplicities.
+See `multroot` to do similar act over polynomials with real coefficients.
 Example:
 ```
 factor(x -> (x-1)^3*(x-2)) 
 ```
-
 """
-function Base.factor(f::Function)
-    p = poly([0.0])
+function factor(f::Function)
+    T = typeof(f(0))
+    p = Polynomials.variable(T)
     try
-        p = convert(Poly, f)
+        p = convert(Poly{T}, f)
     catch e
         throw(DomainError()) # `factor` only works with polynomial functions"
     end
-    factor(p)
+    PolynomialFactors.factor(p)
 end
+
 
 
 end

--- a/test/tests_multroot.jl
+++ b/test/tests_multroot.jl
@@ -52,13 +52,14 @@ fzeros(x -> x^5 - 2x^4 + x^3)
 factor(x -> (x-2)^4*(x-3)^9)
 factor(x -> (x-1)^3 * (x-2)^3 * (x^5 - x + 1))
 factor(x -> x*(x-1)*(x-2)*(x^2 + x + 1))
-
-factor(x -> (x-1)^2 * (x-.99)^2 * (x-1.01)^2) ## can have issue with nearby roots (or high powers)
+factor(x -> x^2 - big(2)^256) # issue #40
 
 factor(x -> (x-1//1)^2 * (x-99//100)^2 * (x-101//100)^2) ## conversion is to Float, not Rational{Int}
 delta = 1//10
 VERSION >= v"0.5.0-" && Primes.factor(convert(Poly{Rational{Int}}, x -> (x-1//1)^2 * (x-1 - delta)^2 * (x-1 + delta)^2))
 
+## factor only works over Integers and rationals, for floats multroot can be used.
+multroot(x -> (x-1)^2 * (x-.99)^2 * (x-1.01)^2) ## can have issue with nearby roots (or high powers)
 
 ## Test conversion of polynomials to Int
 f = x -> 3x^3 - 2x


### PR DESCRIPTION
This removes the naive code for polynomial factors over Z or Q and uses the PolynomialFactor package instead. This closes issues #40.