### PR TITLE
v0.6 fix to test_approx deprecation

### DIFF
--- a/test/test_derivative_free.jl
+++ b/test/test_derivative_free.jl
@@ -6,8 +6,8 @@ orders = [1,2,5,8,16]
 
 fn, x0, alpha = x -> cos(x) - x , 1.0, 0.7390851332151607
 for order in orders
-    @test_approx_eq fzero(fn, x0, order=order) alpha
-    @test_approx_eq fzero(fn, big(x0), order=order) alpha
+    @test fzero(fn, x0, order=order)  ≈ alpha
+    @test fzero(fn, big(x0), order=order)  ≈ alpha
 end
 
 
@@ -17,7 +17,7 @@ x0 = -1.0
 alpha = -1.1673039782614187
 
 for order in orders
-    @test_approx_eq fzero(fn, x0, order=order) alpha
+    @test fzero(fn, x0, order=order)  ≈ alpha
 end
 
 ## failures
@@ -37,11 +37,11 @@ for order in orders[end]
 end
 
 #@test_throws Roots.ConvergenceFailed fzero(fn, x0, order=1)
-@test_approx_eq fn(fzero(fn, x0, order=1, maxsteps = 300))+1 1.0
+@test fn(fzero(fn, x0, order=1, maxsteps = 300))+1  ≈ 1.0
 
 ## trivial
 for order in orders
-    @test_approx_eq fzero(x -> 0.0, 1, order=order)  1.0
-    @test_approx_eq fzero(x -> x, 0.0, order=order)  0.0
+    @test fzero(x -> 0.0, 1, order=order)   ≈ 1.0
+    @test fzero(x -> x, 0.0, order=order)   ≈ 0.0
 end
 

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -76,7 +76,7 @@ for m in [Order0(), Order1()]
     @test_throws Roots.ConvergenceFailed find_zero(fn, -1.0, m)
 end
 for m in [Order2(), Order5(), Order8(), Order16()]
-    @test_approx_eq find_zero(fn, -1.0, m) xstar
+    @test find_zero(fn, -1.0, m)  ≈ xstar
 end
 
 ## non-simple root
@@ -95,10 +95,10 @@ end
 
 ## different types of initial values
 for m in meths
-    @test_approx_eq find_zero(sin, 3, m) pi
-    @test_approx_eq find_zero(sin, 3.0, m) pi
-    @test_approx_eq find_zero(sin, big(3), m) pi
-    @test_approx_eq find_zero(sin, big(3.0), m) pi
+    @test find_zero(sin, 3, m)  ≈ pi
+    @test find_zero(sin, 3.0, m)  ≈ pi
+    @test find_zero(sin, big(3), m)  ≈ pi
+    @test find_zero(sin, big(3.0), m)  ≈ pi
 end
 
 
@@ -106,26 +106,26 @@ end
 fn, xstar, x0 = (x -> sin(x) - x - 1,  -1.9345632107520243, 2)
 @test_throws Roots.ConvergenceFailed find_zero(fn, x0, Order2())
 for m in meths
-    @test_approx_eq find_zero(fn, x0, m, bracket=[-2,3]) xstar
+    @test find_zero(fn, x0, m, bracket=[-2,3])  ≈ xstar
 end
 
 
 fn, xstar, x0 = (x -> x * exp( - x ), 0, 1.0)
-@test_approx_eq find_zero(fn, x0, Order0(), bracket=[-1,2]) xstar
-@test_approx_eq find_zero(fn, 7.0, Order0(), bracket=[-1,2]) xstar  # out of bracket
+@test find_zero(fn, x0, Order0(), bracket=[-1,2])  ≈ xstar
+@test find_zero(fn, 7.0, Order0(), bracket=[-1,2])  ≈ xstar  # out of bracket
 
 ## bisection methods
-@test_approx_eq find_zero(x -> cos(x) - x, [0, pi], Bisection()) 0.7390851332151607
+@test find_zero(x -> cos(x) - x, [0, pi], Bisection())  ≈ 0.7390851332151607
 @test (find_zero(x -> sin(x), [big(3), 4], Bisection()) |> sin) < 1e-70
-@test_approx_eq find_zero(x -> sin(x), [4,3], Bisection()) pi
-@test_approx_eq find_zero(x -> sin(x), [big(4),3], Bisection()) pi
+@test find_zero(x -> sin(x), [4,3], Bisection())  ≈ pi
+@test find_zero(x -> sin(x), [big(4),3], Bisection())  ≈ pi
 
 
 ## Callable objects
 using Polynomials
 x = variable(Float64)
 for m in meths
-    @test_approx_eq find_zero(x^5 - x - 1, 1.0, m) 1.1673039782614187
+    @test find_zero(x^5 - x - 1, 1.0, m)  ≈ 1.1673039782614187
 end
 
 ### a wrapper to count function calls, say
@@ -138,13 +138,13 @@ end
 
 g = Cnt(x -> x^5 - x - 1)
 for m in meths
-    @test_approx_eq find_zero(g, 1.0, m) 1.1673039782614187
+    @test find_zero(g, 1.0, m)  ≈ 1.1673039782614187
 end
 
 
 ## test tolerance arguments
 fn, xstar = x -> sin(x) - x + 1, 1.9345632107520243
-@test_approx_eq find_zero(fn, 20.0, Order2()) xstar   # needs 16 iterations, 33 fn evaluations
+@test find_zero(fn, 20.0, Order2())  ≈ xstar   # needs 16 iterations, 33 fn evaluations
 @test norm(fn(find_zero(fn, 20.0, Order2(), abstol=1e-2)) - xstar) > 1e-12
 @test norm(fn(find_zero(fn, 20.0, Order2(), reltol=1e-2)) - xstar) > 1e-12
 @test_throws Roots.ConvergenceFailed find_zero(fn, 20.0, Order2(), maxevals=10) 

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -8,16 +8,16 @@ orders = [0,1,2,5,8,16]
 
 ### derivative free
 fn, xstar, x0, br = x -> sin(x) - x/2, 1.89549426703398094714, 2.0, [pi/2, pi]
-@test_approx_eq fzero(fn, x0) xstar
+@test fzero(fn, x0)  ≈ xstar
 for o in orders
-    @test_approx_eq fzero(fn, x0, order=o) xstar
+    @test fzero(fn, x0, order=o)  ≈ xstar
 end
 ### bisection
-@test_approx_eq fzero(fn, br) xstar
+@test fzero(fn, br)  ≈ xstar
 
 ### test tolerances
 fn, xstar, x0, br = x -> x^5 - x - 1, 1.1673039782614187, 1.0, [1.0, 2.0]
-@test_approx_eq fzero(fn, x0, order=1) xstar
+@test fzero(fn, x0, order=1)  ≈ xstar
 
 @test_throws Roots.ConvergenceFailed fzero(fn, x0, order=1, maxeval=2)
 #@test norm(fzero(fn, x0, order=1, ftol=1e-2) - xstar) > 1e-5
@@ -29,10 +29,10 @@ fn, xstar, x0, br = x -> x^5 - x - 1, 1.1673039782614187, 1.0, [1.0, 2.0]
 ## various tests
 ## issue #29, basically f(a) or f(b) so big we get NaN for guess from bracket.
 f =  x -> x + exp(x)
-@test_approx_eq fzero(f, 0, [-1e6, 1e6]) -0.5671432904097838
+@test fzero(f, 0, [-1e6, 1e6])  ≈ -0.5671432904097838
 
 ## test infinite range
-@test_approx_eq fzero(x -> x, [-Inf, Inf]) 0.0
+@test fzero(x -> x, [-Inf, Inf])  ≈ 0.0
 
 ##################################################
 ## fzeros function

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -1,27 +1,25 @@
 using Base.Test
 import Roots.newton, Roots.halley
 
-@test_approx_eq_eps newton(sin, cos, 0.5) 0.0 100*eps(1.0)
-@test_approx_eq newton(cos, x -> -sin(x), 1.0) pi/2 
-@test_approx_eq newton(x -> x^2 - 2x - 1, x -> 2x - 2, 3.0) 2.414213562373095
-@test_approx_eq_eps newton(x -> exp(x) - cos(x),
-                           x -> exp(x) + sin(x), 3.0) 0.0 eps(1.0) 
-@test_approx_eq halley(x -> x^2 - 2x - 1,
-                       x -> 2x - 2,
-                       x -> 2, 3.0) 2.414213562373095
-@test_approx_eq_eps halley(x -> exp(x) - cos(x),
-                           x -> exp(x) + sin(x),
-                           x -> exp(x) + cos(x), 3.0) 0.0 eps(1.0)
+@test norm(newton(sin, cos, 0.5) - 0.0) <= 100*eps(1.0)
+@test newton(cos, x -> -sin(x), 1.0)  ≈ pi/2 
+@test newton(x -> x^2 - 2x - 1, x -> 2x - 2, 3.0)  ≈ 2.414213562373095
+@test norm(newton(x -> exp(x) - cos(x), x -> exp(x) + sin(x), 3.0) - 0.0) <= 1e-14
+@test halley(x -> x^2 - 2x - 1,x -> 2x - 2,x -> 2, 3.0)  ≈ 2.414213562373095
+a = halley(x -> exp(x) - cos(x),
+           x -> exp(x) + sin(x),
+           x -> exp(x) + cos(x), 3.0)
+@test norm(a - 0.0) <= 1e-14
 
 
 ## tests with auto derivatives
-@test_approx_eq newton(sin, 3) float(pi)
-@test_approx_eq halley(sin, 3) float(pi)
+@test newton(sin, 3) ≈ pi
+@test halley(sin, 3) ≈ pi
 
 ## More tests with autoderivaitves. Derivative of D operation:
-isdefined(ForwardDiff, :derivative) && @test_approx_eq newton(D(sin), 1.5) pi/2
+isdefined(ForwardDiff, :derivative) && @test newton(D(sin), 1.5) ≈ pi/2
 
 ## test with Complex input
 
-@test_approx_eq real(newton(x ->  x^3 - 1, x ->  3x^2, 1+im)) 1
-@test_approx_eq real(newton(x ->  x^3 - 1, x ->  3x^2, 1+10im)) (-1/2)
+@test real(newton(x ->  x^3 - 1, x ->  3x^2, 1+im)) ≈ 1.0
+@test real(newton(x ->  x^3 - 1, x ->  3x^2, 1+10im)) ≈ (-1/2)


### PR DESCRIPTION
replaces (at)test_approx_eq with \approx[tab], as possible. 