### PR TITLE
Findzero

### DIFF
--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -333,9 +333,13 @@ Find a zero of a univariate function using one of several different methods.
 
 Positional arugments:
 
-* `f` a function or callable object. Most methods are derivative free. Some (`Newton`, `Halley`) may have derivative(s) computed using the `ForwardDiff` pacakge.
+* `f` a function, callable object, or tuple of same. A tuple is used
+  to pass in derivatives, as desired. Most methods are derivative
+  free. Some (`Newton`, `Halley`) may have derivative(s) computed
+  using the `ForwardDiff` pacakge.
 
-* `x0` an initial starting value. Typically a scalar, but may be an array for bisection methods. The value `float(x0)` is passed on.
+* `x0` an initial starting value. Typically a scalar, but may be an
+  array for bisection methods. The value `float(x0)` is passed on.
 
 * `method` one of several methods, see below.
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -7,7 +7,11 @@
 type Newton <: UnivariateZeroMethod
 end
 
-callable_function(method::Newton, f) = FirstDerivative(f, D(f))
+function callable_function(method::Newton, f::Tuple)
+    length(f) == 1 && return FirstDerivative(f[1], D(f[1]))
+    FirstDerivative(f[1], f[2])
+end
+callable_function(method::Newton, f::Any) = FirstDerivative(f, D(f))
 
 function init_state{T}(method::Newton, fs, x0::T)
     state = UnivariateZeroState(x0,
@@ -96,7 +100,7 @@ Keyword arguments:
 
 """
 newton(f, x0; kwargs...) = find_zero(f, x0, Newton(); kwargs...)
-newton(f, fp, x0; kwargs...) = find_zero(f, fp, x0, Newton(); kwargs...)
+newton(f, fp, x0; kwargs...) = find_zero((f, fp), x0, Newton(); kwargs...)
 
 
 ## Halley
@@ -106,8 +110,13 @@ newton(f, fp, x0; kwargs...) = find_zero(f, fp, x0, Newton(); kwargs...)
 type Halley <: UnivariateZeroMethod
 end
 
+function callable_function(method::Halley, f::Tuple)
+    length(f) == 1 && return SecondDerivative(f[1], D(f[1]), D(f[1],2))
+    length(f) == 2 && return SecondDerivative(f[1], f[2], D(f[2],1))
+    SecondDerivative(f[1], f[2], f[3])
+end
 callable_function(method::Halley, f) = SecondDerivative(f, D(f), D(f, 2))
-callable_function(method::Halley, f, fp) = SecondDerivative(f, fp, D(fp))
+
 
 function update_state{T}(method::Halley, fs, o::UnivariateZeroState{T}, options::UnivariateZeroOptions)
     xn = o.xn1
@@ -151,5 +160,5 @@ Keyword arguments:
 
 """
 halley(f,  x0; kwargs...) = find_zero(f, x0, Halley(); kwargs...)
-halley(f, fp, x0; kwargs...) = find_zero(f, fp, x0, Halley(); kwargs...)
-halley(f, fp, fpp, x0; kwargs...) = find_zero(f, fp, fpp, x0, Halley(); kwargs...)
+halley(f, fp, x0; kwargs...) = find_zero((f, fp), x0, Halley(); kwargs...)
+halley(f, fp, fpp, x0; kwargs...) = find_zero((f, fp, fpp), x0, Halley(); kwargs...)

--- a/test/test_derivative_free.jl
+++ b/test/test_derivative_free.jl
@@ -37,11 +37,11 @@ for order in orders[end]
 end
 
 #@test_throws Roots.ConvergenceFailed fzero(fn, x0, order=1)
-@test fn(fzero(fn, x0, order=1, maxsteps = 300))+1  ≈ 1.0
+@test fn(fzero(fn, x0, order=1, maxsteps = 300))+1 ≈ 1.0
 
 ## trivial
 for order in orders
-    @test fzero(x -> 0.0, 1, order=order)   ≈ 1.0
-    @test fzero(x -> x, 0.0, order=order)   ≈ 0.0
+    @test fzero(x -> 0.0, 1, order=order) ≈ 1.0
+    @test fzero(x -> x, 0.0, order=order) ≈ 0.0
 end
 

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -76,7 +76,7 @@ for m in [Order0(), Order1()]
     @test_throws Roots.ConvergenceFailed find_zero(fn, -1.0, m)
 end
 for m in [Order2(), Order5(), Order8(), Order16()]
-    @test find_zero(fn, -1.0, m)  ≈ xstar
+    @test find_zero(fn, -1.0, m) ≈ xstar
 end
 
 ## non-simple root
@@ -95,10 +95,10 @@ end
 
 ## different types of initial values
 for m in meths
-    @test find_zero(sin, 3, m)  ≈ pi
-    @test find_zero(sin, 3.0, m)  ≈ pi
-    @test find_zero(sin, big(3), m)  ≈ pi
-    @test find_zero(sin, big(3.0), m)  ≈ pi
+    @test find_zero(sin, 3, m) ≈ pi
+    @test find_zero(sin, 3.0, m) ≈ pi
+    @test find_zero(sin, big(3), m) ≈ pi
+    @test find_zero(sin, big(3.0), m) ≈ pi
 end
 
 
@@ -106,26 +106,30 @@ end
 fn, xstar, x0 = (x -> sin(x) - x - 1,  -1.9345632107520243, 2)
 @test_throws Roots.ConvergenceFailed find_zero(fn, x0, Order2())
 for m in meths
-    @test find_zero(fn, x0, m, bracket=[-2,3])  ≈ xstar
+    @test find_zero(fn, x0, m, bracket=[-2,3]) ≈ xstar
 end
 
 
 fn, xstar, x0 = (x -> x * exp( - x ), 0, 1.0)
-@test find_zero(fn, x0, Order0(), bracket=[-1,2])  ≈ xstar
-@test find_zero(fn, 7.0, Order0(), bracket=[-1,2])  ≈ xstar  # out of bracket
+@test find_zero(fn, x0, Order0(), bracket=[-1,2]) ≈ xstar
+@test find_zero(fn, 7.0, Order0(), bracket=[-1,2]) ≈ xstar  # out of bracket
 
 ## bisection methods
-@test find_zero(x -> cos(x) - x, [0, pi], Bisection())  ≈ 0.7390851332151607
+@test find_zero(x -> cos(x) - x, [0, pi], Bisection()) ≈ 0.7390851332151607
 @test (find_zero(x -> sin(x), [big(3), 4], Bisection()) |> sin) < 1e-70
-@test find_zero(x -> sin(x), [4,3], Bisection())  ≈ pi
-@test find_zero(x -> sin(x), [big(4),3], Bisection())  ≈ pi
+@test find_zero(x -> sin(x), [4,3], Bisection()) ≈ pi
+@test find_zero(x -> sin(x), [big(4),3], Bisection()) ≈ pi
+
+## defaults for method argument
+@test find_zero(x -> cbrt(x), 1) ≈ 0.0 # order0()
+@test find_zero(sin, [3,4]) ≈ π   # Bisection() 
 
 
 ## Callable objects
 using Polynomials
 x = variable(Float64)
 for m in meths
-    @test find_zero(x^5 - x - 1, 1.0, m)  ≈ 1.1673039782614187
+    @test find_zero(x^5 - x - 1, 1.0, m) ≈ 1.1673039782614187
 end
 
 ### a wrapper to count function calls, say
@@ -138,7 +142,7 @@ end
 
 g = Cnt(x -> x^5 - x - 1)
 for m in meths
-    @test find_zero(g, 1.0, m)  ≈ 1.1673039782614187
+    @test find_zero(g, 1.0, m) ≈ 1.1673039782614187
 end
 
 


### PR DESCRIPTION
* minor change to `find_zero` call. No varargs for function specification, either a callable object or tuple of same for first argument. 
* remove extraneous space in tests