### PR TITLE
fix another NaN problem in bracketing

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -341,7 +341,7 @@ end
 function secant{T}(f, a::T, b)
     c = a - f(a)/(f(b) - f(a))*(b - a)
     tol = eps(T)*5
-    if c <= a + abs(a)*tol || c >= b - abs(b)*tol
+    if isnan(c) || c <= a + abs(a)*tol || c >= b - abs(b)*tol
         return a + (b - a)/2
     end
     return c

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -31,6 +31,9 @@ fn, xstar, x0, br = x -> x^5 - x - 1, 1.1673039782614187, 1.0, [1.0, 2.0]
 f =  x -> x + exp(x)
 @test fzero(f, 0, [-1e6, 1e6])  ≈ -0.5671432904097838
 
+f =  x -> 1/x - 1
+@test fzero(f, [BigFloat(0), 2])  ≈ 1.0
+
 ## test infinite range
 @test fzero(x -> x, [-Inf, Inf])  ≈ 0.0
 


### PR DESCRIPTION
``secant()`` previously chose a guess of ``NaN`` if the function took on
infinite values.  It now chooses ``(a+b)/2``.

This problem did not arise on the code path for ``Float64`` calculations, so it
remained hidden.