### PR TITLE
Allocate

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ Some additional documentation can be read [here](http://nbviewer.ipython.org/url
 ## Polynomials
 
 Special methods for finding roots of polynomials have been moved to
-the `PolynomialZeros` package and its `polyroots(f, domain)` function.
+the `PolynomialZeros` package and its `poly_roots(f, domain)` function.

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -166,7 +166,7 @@ fzeros(p) = Base.depwarn("""
 Calling fzeros with just a polynomial is deprecated.
 Either:
    * Specify an interval to search over: fzeros(p, a, b).
-   * Use the `realroots` function from `PolynomialZeros`                         
+   * Use the `poly_roots(p, Over.R)` call from `PolynomialZeros`                         
    * Use `Polynomials` or `PolynomialRoots` and filter. For example, 
 
 ```

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -52,9 +52,33 @@ function _middle(x::Real, y::Real)
 end
 
 
-## Unexported but much speedier version of bisection method for float64
-## guaranteed to terminate
-function bisection64(f, a::Real, b::Real)
+"""
+
+    `Roots.bisection64(f, a, b)` (unexported)
+
+* `f`: a callable object, like a function
+
+* `a`, `b`: Real values specifying a *bracketing* interval (one with
+`f(a) * f(b) < 0`). These will be converted to `Float64` values.
+
+Runs the bisection method using midpoints determined by a trick
+leveraging 64-bit floating point numbers. After ensuring the
+intermediate bracketing interval does not straddle 0, the "midpoint"
+is half way between the two values onces converted to unsigned 64-bit
+integers. This means no more than 64 steps will be taken, fewer if `a`
+and `b` already share some bits.
+
+The process is guaranteed to return a value `c` with `f(c)` one of
+`0`, `Inf`, or `NaN`; *or* one of `f(prevfloat(c))*f(c) < 0` or
+`f(c)*f(nextfloat(c)) > 0` holding. 
+
+This function is a bit faster than the slightly more general 
+`find_zero(f, [a,b], Bisection())` call.
+
+Due to Jason Merrill.
+
+"""
+function bisection64(f, a::Number, b::Number)
 
     a,b = Float64(a), Float64(b)
 
@@ -65,6 +89,8 @@ function bisection64(f, a::Real, b::Real)
     
     m = _middle(a,b)
     fa, fb = sign(f(a)), sign(f(b))
+
+    fa * fb > 0 && throw(ArgumentError(bracketing_error)) 
     iszero(fa) || isnan(fa) || isinf(fa) && return a
     iszero(fb) || isnan(fb) || isinf(fb) && return b
     
@@ -198,6 +224,8 @@ end
 ##################################################
 
 """
+
+    `Roots.a42(f, a, b; kwargs...)` (not exported)
 
 Finds the root of a continuous function within a provided
 interval [a, b], without requiring derivatives. It is based on algorithm 4.2
@@ -460,6 +488,7 @@ end
 
 
 """
+
 Searches for zeros  of `f` in an interval [a, b].
 
 Basic algorithm used:
@@ -472,10 +501,12 @@ If there are many zeros relative to the number of points, the process
 is repeated with more points, in hopes of finding more zeros for
 oscillating functions.
 
+Called by `fzeros` or `Roots.find_zeros`.
+
 """
 function find_zeros(f, a::Real, b::Real, args...;
                     no_pts::Int=100,
-                    ftol::Real=10*eps(), reltol::Real=10*eps(),
+                    abstol::Real=10*eps(), reltol::Real=10*eps(), ## should be abstol, reltol as used. 
                     kwargs...)
 
     a, b = a < b ? (a,b) : (b,a)
@@ -486,13 +517,13 @@ function find_zeros(f, a::Real, b::Real, args...;
     ## Look in [ai, bi)
     for i in 1:(no_pts+1)
         ai,bi=xs[i:i+1]
-        if isapprox(f(ai), 0.0, rtol=reltol, atol=ftol)
+        if isapprox(f(ai), 0.0, rtol=reltol, atol=abstol)
             push!(rts, ai)
         elseif sign(f(ai)) * sign(f(bi)) < 0
             push!(rts, find_zero(f, [ai, bi], Bisection()))
         else
             try
-                x = find_zero(f, ai + (0.5)* (bi-ai), Order8(); maxevals=10, reltol=ftol, xreltol=reltol)
+                x = find_zero(f, ai + (0.5)* (bi-ai), Order8(); maxevals=10, abstol=abstol, reltol=reltol)
                 if ai < x < bi
                     push!(rts, x)
                 end
@@ -501,11 +532,11 @@ function find_zeros(f, a::Real, b::Real, args...;
         end
     end
     ## finally, b?
-    isapprox(f(b), 0.0, rtol=reltol, atol=ftol) && push!(rts, b)
+    isapprox(f(b), 0.0, rtol=reltol, atol=abstol) && push!(rts, b)
 
     ## redo if it appears function oscillates alot in this interval...
     if length(rts) > (1/4) * no_pts
-        return(find_zeros(f, a, b, args...; no_pts = 10*no_pts, ftol=ftol, reltol=reltol, kwargs...))
+        return(find_zeros(f, a, b, args...; no_pts = 10*no_pts, abstol=abstol, reltol=reltol, kwargs...))
     else
         return(sort(rts))
     end

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -93,8 +93,12 @@ type A42 <: AbstractBisection end
 function find_zero{M<:AbstractBisection, T<:Real}(f, x0::Vector{T}, method::M; maxevals::Int=50, verbose::Bool=false, kwargs...)
     x = sort(float(x0))
     if eltype(x) <: Float64
-        prob, options = derivative_free_setup(method, DerivativeFree(f, f(x0[1])), x; verbose=verbose, maxevals=maxevals, kwargs...)
-        find_zero(prob, method, options)
+        if verbose
+            prob, options = derivative_free_setup(method, DerivativeFree(f, f(x0[1])), x; verbose=verbose, maxevals=maxevals, kwargs...)
+            find_zero(prob, method, options)
+        else # avoid overhead of generic calling method
+            bisection64(f, x0[1], x0[2])::eltype(x)  
+        end
     else
         a42(f, x[1], x[2]; maxeval=maxevals, verbose=verbose)
     end

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -14,20 +14,20 @@
 
 # container for callable objects; not really necessary, but has some value.
 @compat abstract type CallableFunction end
-immutable DerivativeFree <: CallableFunction
-    f
+immutable DerivativeFree{T} <: CallableFunction
+    f::T
 end
 
-immutable FirstDerivative <: CallableFunction
-    f
-    fp
+immutable FirstDerivative{S,T} <: CallableFunction
+    f::S
+    fp::T
 end
 
 
-immutable SecondDerivative <: CallableFunction
-    f
-    fp
-    fpp
+immutable SecondDerivative{S,T,U} <: CallableFunction
+    f::S
+    fp::T
+    fpp::U
 end
 
 ## allows override for automatic derivatives, see Newton

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -7,11 +7,11 @@
 type Newton <: UnivariateZeroMethod
 end
 
-function callable_function(method::Newton, f::Tuple)
+function callable_function(method::Newton, f::Tuple, x0)
     length(f) == 1 && return FirstDerivative(f[1], D(f[1]))
-    FirstDerivative(f[1], f[2])
+    FirstDerivative(f[1], f[2], f[1](x0))
 end
-callable_function(method::Newton, f::Any) = FirstDerivative(f, D(f))
+callable_function(method::Newton, f::Any, x0) = FirstDerivative(f, D(f), x0)
 
 function init_state{T}(method::Newton, fs, x0::T)
     state = UnivariateZeroState(x0,
@@ -143,12 +143,12 @@ newton(f, fp, x0; kwargs...) = find_zero((f, fp), x0, Newton(); kwargs...)
 type Halley <: UnivariateZeroMethod
 end
 
-function callable_function(method::Halley, f::Tuple)
-    length(f) == 1 && return SecondDerivative(f[1], D(f[1]), D(f[1],2))
-    length(f) == 2 && return SecondDerivative(f[1], f[2], D(f[2],1))
-    SecondDerivative(f[1], f[2], f[3])
+function callable_function(method::Halley, f::Tuple, x0)
+    length(f) == 1 && return SecondDerivative(f[1], D(f[1]), D(f[1],2), f[1](x0))
+    length(f) == 2 && return SecondDerivative(f[1], f[2], D(f[2],1), f[1](x0))
+    SecondDerivative(f[1], f[2], f[3], f[1](x0))
 end
-callable_function(method::Halley, f) = SecondDerivative(f, D(f), D(f, 2))
+callable_function(method::Halley, f, x0) = SecondDerivative(f, D(f), D(f, 2), f(x0))
 
 
 function update_state{T}(method::Halley, fs, o::UnivariateZeroState{T}, options::UnivariateZeroOptions)

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -19,7 +19,7 @@ end
 fn, xstar, x0, br = x -> x^5 - x - 1, 1.1673039782614187, 1.0, [1.0, 2.0]
 @test fzero(fn, x0, order=1)  ≈ xstar
 
-@test_throws Roots.ConvergenceFailed fzero(fn, x0, order=1, maxeval=2)
+@test_throws Roots.ConvergenceFailed fzero(fn, x0, order=1, maxevals=2)
 #@test norm(fzero(fn, x0, order=1, ftol=1e-2) - xstar) > 1e-5
 #@test norm(fzero(fn, x0, order=1, xtol=1e-2) - xstar) > 1e-10
 


### PR DESCRIPTION
Two main changes:

* add a return type computed by calling the function on `x0` to the `CallableFunction` struct. This keeps things type stable and reduces some of the excessive allocations
* for bisection over Float64 creates a faster path to a non-allocating `bisection64` method. This path does not respect the keyword arguments unless `verbose=true`, but is much faster.