### PR TITLE
Adjust interface of find_zero

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -114,7 +114,6 @@ end
 ## find_zero interface. We need to specialize for T<:Float64, and BigSomething
 const BigSomething = Union{BigFloat, BigInt}
 
-@compat abstract type AbstractBisection <: UnivariateZeroMethod end
 type Bisection <: AbstractBisection end
 type A42 <: AbstractBisection end
 

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -61,7 +61,6 @@ end
 ##################################################
 
 ## Order0 and Secant are related
-@compat abstract type AbstractSecant <: UnivariateZeroMethod end
 type Order0 <: AbstractSecant end
 type Secant <: AbstractSecant end
 const Order1 = Secant

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -11,6 +11,8 @@
 
 ## method names are subtypes
 @compat abstract type UnivariateZeroMethod end
+@compat abstract type AbstractBisection <: UnivariateZeroMethod end
+@compat abstract type AbstractSecant <: UnivariateZeroMethod end
 
 # container for callable objects; not really necessary, but has some value.
 @compat abstract type CallableFunction{R} end
@@ -402,8 +404,24 @@ find_zero(f, 1.0, Order5())
 find_zero(f, 1.0, Steffensen()) # also Order2()
 ```
 """
-find_zero{T<:Number}(f, x0::Union{T,Vector{T}}, method::UnivariateZeroMethod; kwargs...) =
+function find_zero{M <: AbstractBisection, T<:Number}(f, x0::T, method::M; kwargs...)
+    throw(ArgumentError("For bisection methods, x0 must be a vector"))
+end
+
+function find_zero{T<:Number, M<:AbstractBisection}(f, x0::Vector{T}, method::M; kwargs...)
+    find_zero(method, callable_function(method, f, float(x0[1])), x0; kwargs...)
+end
+
+function find_zero{T<:Number}(f, x0::T, method::UnivariateZeroMethod; kwargs...)
     find_zero(method, callable_function(method, f, float(x0)), x0; kwargs...)
+end
+
+function find_zero{T<:Number}(f, x0::T, method::AbstractSecant; kwargs...)
+    find_zero(method, callable_function(method, f, float(x0)), x0; kwargs...)
+end
+function find_zero{T<:Number}(f, x0::Vector{T}, method::AbstractSecant; kwargs...)
+    find_zero(method, callable_function(method, f, float(x0[1])), x0; kwargs...)
+end
 
 ## some defaults for methods
 find_zero{T <: Number}(f, x0::T; kwargs...) = find_zero(f, x0, Order0(); kwargs...)

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -119,7 +119,7 @@ fn, xstar, x0 = (x -> x * exp( - x ), 0, 1.0)
 @test (find_zero(x -> sin(x), [big(3), 4], Bisection()) |> sin) < 1e-70
 @test find_zero(x -> sin(x), [4,3], Bisection()) ≈ pi
 @test find_zero(x -> sin(x), [big(4),3], Bisection()) ≈ pi
-
+@test_throws ArgumentError  find_zero(x -> sin(x), 3.0, Bisection())
 ## defaults for method argument
 @test find_zero(x -> cbrt(x), 1) ≈ 0.0 # order0()
 @test find_zero(sin, [3,4]) ≈ π   # Bisection() 


### PR DESCRIPTION
This fixes a bug in calling `find_zero` with a Bisection method when `x0` is a scalar. This is now disallowed.