### PR TITLE
Fix Inf handling in bisection64

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -91,8 +91,8 @@ function bisection64(f, a::Number, b::Number)
     fa, fb = sign(f(a)), sign(f(b))
 
     fa * fb > 0 && throw(ArgumentError(bracketing_error)) 
-    iszero(fa) || isnan(fa) || isinf(fa) && return a
-    iszero(fb) || isnan(fb) || isinf(fb) && return b
+    (iszero(fa) || isnan(fa) || isinf(fa)) && return a
+    (iszero(fb) || isnan(fb) || isinf(fb)) && return b
     
     while a < m < b
         fm = sign(f(m))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+SpecialFunctions 0.1.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Roots
 using Base.Test
+import SpecialFunctions.erf
 
 include("./test_find_zero.jl")
 #include("./RootTesting.jl")

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -14,6 +14,7 @@ for o in orders
 end
 ### bisection
 @test fzero(fn, br)  ≈ xstar
+@test fzero(x->5-x,5,10)==5
 
 ### test tolerances
 fn, xstar, x0, br = x -> x^5 - x - 1, 1.1673039782614187, 1.0, [1.0, 2.0]


### PR DESCRIPTION
Make sure bisection works if the root is on the boundary of the interval. I also added an appropriate test