### PR TITLE
False position

### DIFF
--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -17,7 +17,7 @@ export multroot, D2  # deprecated
 
 export find_zero,
        Order0, Order1, Order2, Order5, Order8, Order16
-export Bisection
+export Bisection, FalsePosition
 # export Bisection, Secant, Steffensen, Newton, Halley
 
 ## load in files

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -78,17 +78,13 @@ function init_state{T <: AbstractFloat}(method::AbstractSecant, fs, x::Union{T, 
         x0, x1, fx0, fx1  = x1, x0, fs.f(x1), fx0 # switch
     end
 
-    state = UnivariateZeroState(
-                                promote(float(x1), float(x0))...,
-                                promote(fx1, fx0)...,
-                                isa(bracket, Nullable) ? bracket : Nullable(convert(Vector{T}, sort(bracket))),
-                                0,
-                                2,
-                                false,
-                                false,
-                                false,
-                                false,
-                                "")
+    state = UnivariateZeroStateBase(
+                                    promote(float(x1), float(x0))...,
+                                    promote(fx1, fx0)...,
+                                    isa(bracket, Nullable) ? bracket : Nullable(convert(Vector{T}, sort(bracket))),
+                                    0, 2,
+                                    false, false, false, false,
+                                    "")
     state
 end
 

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -44,7 +44,7 @@ function callable_function(m::UnivariateZeroMethod, f, x0)
 end
 
 
-## object to hold state
+## object to hold state; allow for subtypes with additional fields
 @compat abstract type  UnivariateZeroState{T, S} end
 type UnivariateZeroStateBase{T,S} <: UnivariateZeroState{T,S}
     xn1::T
@@ -52,22 +52,6 @@ type UnivariateZeroStateBase{T,S} <: UnivariateZeroState{T,S}
     fxn1::S
     fxn0::S
     bracket::Nullable{Vector{T}}
-    steps::Int
-    fnevals::Int
-    stopped::Bool             # stopped, butmay not have converged
-    x_converged::Bool         # converged via |x_n - x_{n-1}| < ϵ
-    f_converged::Bool         # converged via |f(x_n)| < ϵ
-    convergence_failed::Bool
-    message::AbstractString
-end
-
-type UnivariateZeroStateBracketing{T,S} <: UnivariateZeroState{T,S}
-    xn1::T
-    xn0::T
-    fxn1::S
-    fxn0::S
-    bracket::Nullable{Vector{T}}
-    flag::Symbol
     steps::Int
     fnevals::Int
     stopped::Bool             # stopped, butmay not have converged

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -13,21 +13,15 @@ function callable_function(method::Newton, f::Tuple, x0)
 end
 callable_function(method::Newton, f::Any, x0) = FirstDerivative(f, D(f), x0)
 
-function init_state{T}(method::Newton, fs, x0::T)
-    state = UnivariateZeroState(x0,
-                                x0 + typemax(Int),
-                                fs.f(x0),
-                                fs.f(x0),
-                                Nullable{Vector{T}}(),
-                                0,
-                                1,
-                                false,
-                                false,
-                                false,
-                                false,
-                                "")
-    state
-end
+# function init_state{T}(method::Newton, fs, x0::T)
+#     state = UnivariateZeroStateBase(x0, x0 + typemax(Int),
+#                                     fs.f(x0), fs.f(x0),
+#                                     Nullable{Vector{T}}(),
+#                                     0, 1,
+#                                     false, false, false, false,
+#                                     "")
+#     state
+# end
 
 function update_state{T}(method::Newton, fs, o::UnivariateZeroState{T}, options::UnivariateZeroOptions)
     xn = o.xn1

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -119,7 +119,15 @@ fn, xstar, x0 = (x -> x * exp( - x ), 0, 1.0)
 @test (find_zero(x -> sin(x), [big(3), 4], Bisection()) |> sin) < 1e-70
 @test find_zero(x -> sin(x), [4,3], Bisection()) ≈ pi
 @test find_zero(x -> sin(x), [big(4),3], Bisection()) ≈ pi
+@test find_zero(x -> cos(x) - x, [0, pi], FalsePosition()) ≈ 0.7390851332151607
+@test (find_zero(x -> sin(x), [big(3), 4], FalsePosition()) |> sin) < 1e-70
+@test find_zero(x -> sin(x), [4,3], FalsePosition()) ≈ pi
+
 @test_throws ArgumentError  find_zero(x -> sin(x), 3.0, Bisection())
+
+
+
+
 ## defaults for method argument
 @test find_zero(x -> cbrt(x), 1) ≈ 0.0 # order0()
 @test find_zero(sin, [3,4]) ≈ π   # Bisection() 

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -119,11 +119,50 @@ fn, xstar, x0 = (x -> x * exp( - x ), 0, 1.0)
 @test (find_zero(x -> sin(x), [big(3), 4], Bisection()) |> sin) < 1e-70
 @test find_zero(x -> sin(x), [4,3], Bisection()) ≈ pi
 @test find_zero(x -> sin(x), [big(4),3], Bisection()) ≈ pi
+@test_throws ArgumentError  find_zero(x -> sin(x), 3.0, Bisection())
+
 @test find_zero(x -> cos(x) - x, [0, pi], FalsePosition()) ≈ 0.7390851332151607
-@test (find_zero(x -> sin(x), [big(3), 4], FalsePosition()) |> sin) < 1e-70
+@test (find_zero(x -> sin(x), [big(3), 4], FalsePosition(), maxevals=100) |> sin) < 1e-70
 @test find_zero(x -> sin(x), [4,3], FalsePosition()) ≈ pi
 
-@test_throws ArgumentError  find_zero(x -> sin(x), 3.0, Bisection())
+galadino_probs = [(x -> x^3 - 1, [.5, 1.5]),
+                  (x -> x^2 * (x^2/3 + sqrt(2) * sin(x)) - sqrt(3)/18, [.1, 1]),
+                  (x -> 11x^11 - 1, [0.1, 1]),
+                  (x ->  x^3 + 1, [-1.8, 0]),
+                  (x ->  x^3 - 2x - 5, [2.0, 3]),
+                  
+                  ((x,n=5)  -> 2x * exp(-n) + 1 - 2exp(-n*x) , [0,1]),
+                  ((x,n=10) -> 2x * exp(-n) + 1 - 2exp(-n*x) , [0,1]),
+                  ((x,n=20) -> 2x * exp(-n) + 1 - 2exp(-n*x) , [0,1]),
+
+                  ((x,n=5)  -> (1 + (1-n)^2) * x^2 - (1 - n*x)^2 , [0,1]),
+                  ((x,n=10) -> (1 + (1-n)^2) * x^2 - (1 - n*x)^2 , [0,1]),
+                  ((x,n=20) -> (1 + (1-n)^2) * x^2 - (1 - n*x)^2 , [0,1]),
+
+                  ((x,n=5)  -> x^2 - (1-x)^n , [0,1]),
+                  ((x,n=10) -> x^2 - (1-x)^n , [0,1]),
+                  ((x,n=20) -> x^2 - (1-x)^n , [0,1]),
+
+                  ((x,n=5)  -> (1 + (1-n)^4)*x - (1 - n*x)^4 , [0,1]),
+                  ((x,n=10) -> (1 + (1-n)^4)*x - (1 - n*x)^4 , [0,1]),
+                  ((x,n=20) -> (1 + (1-n)^4)*x - (1 - n*x)^4 , [0,1]),
+
+                  ((x,n=5)  -> exp(-n*x)*(x-1) + x^n , [0,1]),
+                  ((x,n=10) -> exp(-n*x)*(x-1) + x^n , [0,1]),
+                  ((x,n=20) -> exp(-n*x)*(x-1) + x^n , [0,1]),
+
+                  ((x,n=5)  -> x^2 + sin(x/n) - 1/4 , [0,1]),
+                  ((x,n=10) -> x^2 + sin(x/n) - 1/4 , [0,1]),
+                  ((x,n=10) -> x^2 + sin(x/n) - 1/4 , [0,1])
+                  ]
+        
+
+for (fn, ab) in galadino_probs
+    for m in [Roots.A42(), Bisection(), (FalsePosition(i) for i in 1:12)...]
+        x0 = find_zero(fn, ab, m, maxevals=120)
+        @test norm(fn(x0)) <= 1e-14
+    end
+end
 
 
 


### PR DESCRIPTION
Closes #80 

This implements 12 variants of the false position method, as discussed in Galdino. For many functions these give a bracketed zero-finding algorithm taking many fewer function calls than bisection, though some will take more function calls. The interface is through `find_roots`, as in `find_roots(sin, [3, 4], FalsePosition())`. The different variants are accessed by number (`FalsePosition(4)`, say) or by one of three names (e.g, `FalsePosition(:illinois)`.) Some documentation is found through `?FalsePosition`.