### PR TITLE
Fix ipzero would evaluate the function at an invalid point.

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -545,11 +545,10 @@ function ipzero(f, a, fa, b, fb, c, fc, d, fd)
     D32 = (D31 - Q21)*fc/(fc - fa)
     Q33 = (D32 - Q22)*fa/(fd - fa)
     c = a + (Q31 + Q32 + Q33)
-    fc = f(c)
     if (c <= a) || (c >= b)
-        c, fc = newton_quadratic(f, a, fa, b, fb, d, fd, 3)
+        return newton_quadratic(f, a, fa, b, fb, d, fd, 3)
     end
-    return c, fc
+    return c, f(c)
 end
 
 


### PR DESCRIPTION
I made a mistake in the a42 pull request: there is one place where it would incorrectly evaluate the function at a point before checking if the point is valid.

Test case:
```
function test_ipzero()
    let (r, a, θ) = (1.0, -1.0, 0.01)
        @test_nowarn Roots.a42(e -> e*e+r/a*sin(θ)*sqrt(muladd(e,e,-1))+r/a*(1-cos(θ))-1, 1+1e-8, 10.0)
    end
end
```
  