### PR TITLE
Make find roots find more roots w/ complex allowed

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -772,15 +772,13 @@ function _find_recursive_zeros(f, a::Real, b::Real, args...;
     )
 
     for (cur_a, cur_b) in cur_intervals
-        isapprox(cur_a, cur_b, rtol=reltol) && continue
-        isapprox(cur_a, cur_b, atol=abstol) && continue
+        loose_isapprox(cur_a, cur_b, abstol, reltol) && continue
 
         tmp_a = find_next_non_root(cur_a, f, cur_b, reltol, abstol)
         tmp_b = find_next_non_root(cur_b, f, cur_a, reltol, abstol)
 
         isnan(tmp_a) || isnan(tmp_b) && continue
-        isapprox(tmp_a, tmp_b, rtol=reltol) && continue
-        isapprox(tmp_a, tmp_b, atol=abstol) && continue
+        loose_isapprox(tmp_a, tmp_b, abstol, reltol) && continue
         ( tmp_a < tmp_b ) || continue
 
         cur_roots = _find_recursive_zeros(
@@ -802,10 +800,7 @@ function find_next_non_root(cur_root, cur_func, barrier_point, reltol, abstol)
     cur_value = cur_root + cur_adder
 
     while sign(barrier_point - cur_value) == cur_direction
-        needs_skip = isapprox(cur_value, cur_root, rtol=reltol)
-        needs_skip |= isapprox(cur_value, cur_root, atol=abstol)
-
-        if !needs_skip
+        if !loose_isapprox(cur_value, cur_root, abstol, reltol)
           cur_f = cur_func(cur_value)
           isapprox(cur_f, 0.0, atol=abstol) || break
         end
@@ -820,8 +815,7 @@ function find_next_non_root(cur_root, cur_func, barrier_point, reltol, abstol)
     for tmp_value in linspace(cur_value - cur_adder, cur_value)
         ( sign(tmp_value - cur_root) == cur_direction ) || continue
 
-        isapprox(tmp_value, cur_root, rtol=reltol) && continue
-        isapprox(tmp_value, cur_root, atol=abstol) && continue
+        loose_isapprox(tmp_value, cur_root, abstol, reltol) && continue
 
         cur_f = cur_func(tmp_value)
 
@@ -910,4 +904,11 @@ function find_order_root(f, cur_range::AbstractVector{T}, abstol::Real, reltol::
     end
 
     cur_root
+end
+
+function loose_isapprox(first_value, second_value, atol, rtol)
+  isapprox(first_value, second_value, atol=atol) && return true
+  isapprox(first_value, second_value, rtol=rtol) && return true
+
+  false
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,3 +14,5 @@ include("./test_fzero.jl")
 include("./test_newton.jl")
 
 #include("./test_derivative_free.jl")
+
+include("./test_find_zeros.jl")

--- a/test/test_find_zeros.jl
+++ b/test/test_find_zeros.jl
@@ -1,0 +1,79 @@
+using Roots
+using Compat.Test
+
+
+@testset "find_zeros" begin
+
+    rts = find_zeros(x -> exp(x) - x^4, -5, 20)
+    @test length(rts) == 3
+
+    n = 10
+    rts = find_zeros(x -> cos(x)/n, 0, 10)
+    @test length(rts) == 3
+
+    W(n) = x -> prod(x-i for i in 1:n)
+    rts = find_zeros(W(20), -1, 21)
+    @test length(rts) == 20
+
+    W1(n) = x -> prod((x-i)^i for i in 1:n)
+    rts = find_zeros(W1(5), -0.5, 5.5, rtol=1e-12) # o/w even powers hard
+    @test length(rts) == 5
+
+    T11(x) = 1024*x^11 - 2816x^9  + 2816x^7 - 1232x^5 + 220x^3 - 11x
+    rts = find_zeros(T11, -1.0, 1.0)
+    @test length(rts) == 11
+
+    U9(x) = 512x^9 - 1024x^7 + 672x^5 - 160x^3 + 10x
+    rts = find_zeros(U9, -1.0, 1.0)
+    @test length(rts) == 9 # all rts real and in (-1,1) for Chebyshev
+
+end
+
+
+#http://www.chebfun.org/examples/roots/Tiger.html
+tiger_tail(x) = 2*exp(.5*x) *(sin(5*x) + sin(101*x))
+f1(x) = tiger_tail(x) - round(tiger_tail(x)) # (-2,1) then filter
+
+f2(x) = (x-0.5)*(x-0.5001)*(x-4)*(x-4.05)*(x-9.3) # (0,10)
+f3(x) = (x-3)^2*(x-4)^2 # (0,5)
+delta1 = .01
+f4(x) = (x-0.5)^2 * (x - (0.5+delta1))^2 # (0,1)
+delta = .001
+f5(x) = (x - 0.5)^3 * (x - (0.5+delta)) * (x - 1)
+# f6(x) = (x - 0.5)^3 * (x - (0.5+delta))^3 * (x-4)*(x-(4+delta))*(x-4.2)^2
+
+## test number of function calls with this
+mutable struct CallableFunction
+f
+n
+end
+(F::CallableFunction)(x) = (F.n+=1; F.f(x))
+f7 = CallableFunction(x -> sin(x-0.1), 0)
+
+
+@testset "find_zeros harder ones" begin
+
+    rts = find_zeros(f1, -2.0, 1.0, xatol=1e-4,xrtol=1e-4) # o/w misses a few
+    rts = filter(u -> -1/4 < f1(u) < 1/4, rts)
+    @test length(rts) == 345
+
+    rts = find_zeros(f2, 0.0, 10.0)
+    @test length(rts) == 5
+
+    rts = find_zeros(f3, 0.0, 5.0)
+    @test length(rts) == 2
+
+    rts = find_zeros(f4, 0.0, 1.0)  # fussy
+    @test length(rts) == 2
+
+    # need to crank up xatol, xrtol to find smaller gaps (d=0.001)
+    rts = find_zeros(f5, 0.0, 1.1, xatol=1e-5, xrtol=1e-5)
+    @test length(rts) == 3
+
+    # rts = find_zeros(f6, 0.0, 5.0, xatol=1e-5, xrtol=1e-5)
+    # @test length(rts) == 5
+
+    rts = find_zeros(f7, -pi/2, pi/2)
+    @test f7.n <= 6000 # 3002
+
+end

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -45,7 +45,7 @@ rts = 1:5
 
 
 fn = x -> sin(10*pi*x)
-@test length(fzeros(fn, 0, 1)) == 11
+@test length(fzeros(fn, 0, 1)) == 10
 
 ### issue with fzeros and roots near 'b'
 @test 0 <  maximum(fzeros(x -> sin(x) - 1/1000*x, 0, pi)) < pi


### PR DESCRIPTION
Made in favor of changes from:

+ https://github.com/JuliaMath/Roots.jl/pull/108

**update:** guessing the failed jobs on windows are from that convert magic you did before. don't have a way to test this though

------

Also, it took **1395** calls to solve the following root equation:

```
    f7 = CallableFunction(x -> sin(x-0.1), 0)
    rts = find_zeros(f7, -pi/2, pi/2)
    println(f7.n)
    @test f7.n <= 6000 # 3002
```