### PR TITLE
fixed 0.7 depwarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
 julia:
   - 0.6
+  - 0.7
   - nightly
 matrix:
   allow_failures:

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -649,7 +649,11 @@ end
 
 # floating point comparison function
 function almost_equal(x::T, y::T) where {T}
-    min_diff = oneunit(x) * realmin(float(x/oneunit(x)))*32
+    if VERSION < v"0.7.0-beta2.169"
+        min_diff = oneunit(x) * realmin(float(x/oneunit(x)))*32
+    else
+        min_diff = oneunit(x) * floatmin(float(x/oneunit(x)))*32
+    end
     abs(x - y) < min_diff
 end
 


### PR DESCRIPTION
replace `realmin` with `floatmin` to fix 0.7 depwarn