### PR TITLE
streamline tolerances code, document address #122

### DIFF
--- a/src/find_zeros.jl
+++ b/src/find_zeros.jl
@@ -81,7 +81,7 @@ function find_non_zero(f, a::T, barrier, xatol, xrtol, atol, rtol) where {T}
     sgn = barrier > a ? 1 : -1 
     ctr = 0
     x = a + 2^ctr*sgn*xtol
-    while !_non_zero(float(f(x)), x, atol, rtol)
+    while !_non_zero(f(x), x, atol, rtol)
         ctr += 1
         x += 2^ctr*sgn*xtol
         ((sgn > 0 && x > barrier) || (sgn < 0 && x < barrier)) && return nan
@@ -219,10 +219,11 @@ function find_zeros(f, a, b; no_pts = 12, k=8,
     # set tolerances if not specified
     fa0 = f(a0)
     d = Dict(kwargs)
-    xatol = get(d, :xatol, oneunit(a0) * eps(one(a0))^(4/5))
-    xrtol = get(d, :xrtol, eps(one(a0)))
-    atol  = get(d, :atol,  eps(oneunit(fa0)))
-    rtol  = get(d, :rtol,  eps(one(fa0)))
+    T, S = eltype(a0), eltype(fa0)
+    xatol = get(d, :xatol, eps(one(T))^(4/5) * oneunit(T))
+    xrtol = get(d, :xrtol, eps(one(T)) * one(T))
+    atol  = get(d, :atol,  eps(float(S)) * oneunit(S))
+    rtol  = get(d, :rtol,  eps(float(S)) * one(S))
     
     T = eltype(a0)
 

--- a/test/test_composable.jl
+++ b/test/test_composable.jl
@@ -26,8 +26,10 @@ using SymEngine
         for order in orders
             @test find_zero(y, 1.8s, order) ≈  1.886053370668014s
         end
-        
-        @test find_zero(y, (1.8s, 1.9s), Bisection()) ≈ 1.886053370668014s
+
+        for M in [Roots.Bisection(), Roots.A42(), Roots.AlefeldPotraShi()]
+            @test find_zero(y, (1.8s, 1.9s), M) ≈ 1.886053370668014s
+        end
         
         xrts = find_zeros(y, 0s, 10s)
         @test length(xrts) == 1
@@ -47,14 +49,16 @@ using SymEngine
         
         @vars x
         for order in orders
-            @test find_zero(y(x), 1.8s, order) ≈  1.886053370668014
+            @test find_zero(y(x), 1.8, order) ≈  1.8860533706680143
         end
-        
-        @test find_zero(y(x), (1.8, 1.9), Bisection()) ≈ 1.886053370668014
+
+        for M in [Roots.Bisection(), Roots.A42(), Roots.AlefeldPotraShi()]
+            @test find_zero(y(x), (1.8, 1.9), M) ≈ 1.8860533706680143
+        end
         
         xrts = find_zeros(y(x), 0, 10)
         @test length(xrts) == 1
-        @test xrts[1] ≈  1.886053370668014
+        @test xrts[1] ≈  1.8860533706680143
     end
 
 


### PR DESCRIPTION
Streamlines handling of default tolerances, improves documentation of defaults, fixed issue with `find_zeros` and some number types.