### PR TITLE
Quad step

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -271,7 +271,7 @@ end
 ## Bisection has special cases
 ## for zero tolerance, we have either BisectionExact or A42 methods
 ## for non-zero tolerances, we have use thegeneral Bisection method
-function find_zero(fs, x0, method::Union{Bisection};
+function find_zero(fs, x0, method::M;
                    tracks = NullTracks(),
                    verbose=false,
                    kwargs...) where {M <: Union{Bisection}}

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -3,7 +3,7 @@
 ## * a graphic of trace when verbose=true?
 
 
-# 
+#
 # In McNamee & Pan (DOI:10.1016/j.camwa.2011.11.015 there are a number of
 # results on efficiencies of a solution, (1/d) log_10(q)
 # Those implemented here are:
@@ -34,7 +34,7 @@ abstract type AbstractNonBracketing <: AbstractUnivariateZeroMethod end
 abstract type AbstractSecant <: AbstractNonBracketing end
 
 
-### States    
+### States
 abstract type  AbstractUnivariateZeroState end
 mutable struct UnivariateZeroState{T,S} <: AbstractUnivariateZeroState where {T,S}
     xn1::T
@@ -61,7 +61,7 @@ function init_state(method::Any, fs, x)
     x1 = float(x)
     fx1 = fs(x1); fnevals = 1
     T, S = eltype(x1), eltype(fx1)
-    
+
     state = UnivariateZeroState(x1, oneunit(x1) * (0*x1)/(0*x1), T[],
                                 fx1, oneunit(fx1) * (0*fx1)/(0*fx1), S[],
                                 0, fnevals,
@@ -173,7 +173,7 @@ function default_tolerances(::AbstractUnivariateZeroMethod, ::Type{T}, ::Type{S}
     strict = false
     (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
 end
-                         
+
 function init_options(M::AbstractUnivariateZeroMethod,
                       state::UnivariateZeroState{T,S};
                       kwargs...
@@ -238,7 +238,7 @@ function show_tracks(s::Tracks, M::AbstractUnivariateZeroMethod)
     println("")
 end
 
-    
+
 
 ### Functions
 abstract type CallableFunction end
@@ -271,7 +271,7 @@ end
 
 
 
-struct DerivativeFree <: CallableFunction 
+struct DerivativeFree <: CallableFunction
     f
 end
 
@@ -332,30 +332,30 @@ end
 Assess if algorithm has converged.
 
 If alogrithm hasn't converged returns `false`.
-    
+
 If algorithm has stopped or converged, return `true` and sets one of `state.stopped`, `state.x_converged`,  `state.f_converged`, or `state.convergence_failed`; as well, a message may be set.
 
 * `state.x_converged = true` if `abs(xn1 - xn0) < max(xatol, max(abs(xn1), abs(xn0)) * xrtol)`
 
-* `state.f_converged = true` if  `|f(xn1)| < max(atol, |xn1|*rtol)` 
+* `state.f_converged = true` if  `|f(xn1)| < max(atol, |xn1|*rtol)`
 
 * `state.convergence_failed = true` if xn1 or fxn1 is `NaN` or an infinity
 
 * `state.stopped = true` if the number of steps exceed `maxevals` or the number of function calls exceeds `maxfnevals`.
 
 In `find_zero`, stopped values (and x_converged) are checked for convergence with a relaxed tolerance.
-    
 
-"""    
+
+"""
 function assess_convergence(method::Any, state::UnivariateZeroState{T,S}, options) where {T,S}
 
     xn0, xn1 = state.xn0, state.xn1
     fxn1 = state.fxn1
-    
+
     if (state.x_converged || state.f_converged || state.stopped)
         return true
     end
-    
+
     if state.steps > options.maxevals
         state.stopped = true
         state.message *= "Too many steps taken. "
@@ -373,7 +373,7 @@ function assess_convergence(method::Any, state::UnivariateZeroState{T,S}, option
         state.message *= "NaN produced by algorithm. "
         return true
     end
-    
+
     if isinf(xn1) || isinf(fxn1)
         state.convergence_failed = true
         state.message *= "Inf produced by algorithm. "
@@ -456,22 +456,22 @@ If no method is specified, the default method depends on `x0`:
 
 * If `x0` is a tuple or vector indicating a *bracketing* interval, the `Bisection` method is used. (The exact algorithm depends on the number type, the tolerances, and `verbose`.)
 
-# Specifying the function 
+# Specifying the function
 
-The function(s) are passed as the first argument. 
+The function(s) are passed as the first argument.
 
 For the few methods that use a derivative (`Newton`, `Halley`, and
-optionally `Order5`) a tuple of functions is used. 
+optionally `Order5`) a tuple of functions is used.
 
 # Optional arguments (tolerances, limit evaluations, tracing)
 
 * `xatol` - absolute tolerance for `x` values. Passed to `isapprox(x_n, x_{n-1})`
 * `xrtol` - relative tolerance for `x` values. Passed to `isapprox(x_n, x_{n-1})`
-* `atol`  - absolute tolerance for `f(x)` values. 
-* `rtol`  - relative tolerance for `f(x)` values. 
-* `maxevals`   - limit on maximum number of iterations 
+* `atol`  - absolute tolerance for `f(x)` values.
+* `rtol`  - relative tolerance for `f(x)` values.
+* `maxevals`   - limit on maximum number of iterations
 * `maxfnevals` - limit on maximum number of function evaluations
-* `strict` - if `false` (the default), when the algorithm stops, possible zeros are checked with a relaxed tolerance    
+* `strict` - if `false` (the default), when the algorithm stops, possible zeros are checked with a relaxed tolerance
 * `verbose` - if `true` a trace of the algorithm will be shown on successful completion.
 
 See the help string for `Roots.assess_convergence` for details on
@@ -488,7 +488,7 @@ For the `Bisection` methods, convergence is guaranteed, so the tolerances are se
 
 
 If a bracketing method is passed in after the method specification if a bracket is found, the method will switch. This is what `Order0` does by default, with a secant step initially.
-    
+
 # Examples:
 
 ```
@@ -538,8 +538,8 @@ function _find_zero(F, x0, method::AbstractUnivariateZeroMethod,
                     N::Union{Nothing, AbstractBracketing}=nothing;
                     tracks::AbstractTracks=NullTracks(),
                     verbose=false,
-                    kwargs...)    
-    
+                    kwargs...)
+
 
     state = init_state(method, F, x0)
     options = init_options(method, state; kwargs...)
@@ -561,7 +561,7 @@ function _find_zero(F, x0, method::AbstractUnivariateZeroMethod,
     else
         return xstar
     end
-    
+
 end
 
 find_zero(f, x0::T; kwargs...)  where {T <: Number}= find_zero(f, x0, Order0(); kwargs...)
@@ -579,7 +579,7 @@ function find_zero(M::AbstractUnivariateZeroMethod,
                    )  #where {T<:Number, S<:Number}
 
     log_step(l, M, state, :init)
-    
+
     while true
         val = assess_convergence(M, state, options)
         val && break
@@ -595,7 +595,7 @@ end
 function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state, options)
     xn1 = state.xn1
     fxn1 = state.fxn1
-    
+
     if (state.stopped || state.x_converged) && !(state.f_converged)
         ## stopped is a heuristic, x_converged can mask issues
         ## if strict == false, this will also check f(xn) ~ - with a relaxed
@@ -610,7 +610,7 @@ function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state, options)
                 state.f_converged = true
             end
         end
-        
+
         if options.strict
             if state.x_converged
                 state.f_converged = true
@@ -628,14 +628,14 @@ function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state, options)
             end
         end
     end
-    
+
     if state.f_converged
         return state.xn1
     end
 
     nan = NaN * state.xn1
     if state.convergence_failed
-        return nan        
+        return nan
     end
     return nan
 
@@ -676,7 +676,7 @@ function find_zero(M::AbstractUnivariateZeroMethod,
                    l::AbstractTracks=NullTracks()
                    )
 
-    
+
     log_step(l, M, state, :init)
     state0 = copy(state)
     quad_ctr = 0
@@ -701,8 +701,8 @@ function find_zero(M::AbstractUnivariateZeroMethod,
             run_bisection(N, F, (a, b), state, options)
             break
         end
-            
-            
+
+
         ## did we move too far?
         r, a, b = state0.xn1, state.xn0, state.xn1
         Δr = abs(r - b)
@@ -744,8 +744,17 @@ function find_zero(M::AbstractUnivariateZeroMethod,
             if isnan(r) || isinf(r)
                 copy!(state, state0)
             else
+
+                fr = F(r)
+                incfn(state)
+
+                if sign(fr) * sign(state.fxn1) < 0
+                    # find zero from newton_quadratic to avoid potential floating point errors with quad_vertex
+                    r = newton_quadratic(state0.xn1, state.xn0, state.xn1, state0.fxn1, state.fxn0, state.fxn1,1)
+                    fr = F(r); incfn(state)
+                end
                 state0.xn1 = r
-                state0.fxn1 = F(r)
+                state0.fxn1 = fr
                 incfn(state)
                 copy!(state, state0)
             end
@@ -754,8 +763,6 @@ function find_zero(M::AbstractUnivariateZeroMethod,
         log_step(l, M, state)
         incsteps(state)
     end
-    
+
     decide_convergence(M, F, state, options)
 end
-
-    

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -753,6 +753,7 @@ function find_zero(M::AbstractUnivariateZeroMethod,
                     r = newton_quadratic(state0.xn1, state.xn0, state.xn1, state0.fxn1, state.fxn0, state.fxn1,1)
                     fr = F(r); incfn(state)
                 end
+
                 state0.xn1 = r
                 state0.fxn1 = fr
                 incfn(state)

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -751,7 +751,7 @@ function find_zero(M::AbstractUnivariateZeroMethod,
         else
 
             quad_ctr += 1
-            r = Roots.quad_vertex(state0.xn1, state0.fxn1, state.xn1, state.fxn1, state.xn0, state.fxn0)
+            r = quad_vertex(state0.xn1, state0.fxn1, state.xn1, state.fxn1, state.xn0, state.fxn0)
 
             if isnan(r) || isinf(r)
                 copy!(state, state0)
@@ -759,12 +759,6 @@ function find_zero(M::AbstractUnivariateZeroMethod,
 
                 fr = F(r)
                 incfn(state)
-
-                if sign(fr) * sign(state.fxn1) < 0
-                    # find zero from newton_quadratic to avoid potential floating point errors with quad_vertex
-                    r = newton_quadratic(state0.xn1, state.xn0, state.xn1, state0.fxn1, state.fxn0, state.fxn1,1)
-                    fr = F(r); incfn(state)
-                end
 
                 state0.xn1 = r
                 state0.fxn1 = fr

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -66,23 +66,9 @@ function guarded_secant_step(alpha, beta, falpha, fbeta)
 end
 
 
-# for the 3 points, find parabola. Then return vertex of the closest 0
-# to the mean of x1, x2, x3
+# for the 3 points, find parabola vertex
 function quad_vertex(x1,fx1,x2,fx2,x3,fx3)
     vertex = -(-fx1*(x2^2 - x3^2) + fx2*(x1^2 - x3^2) - fx3*(x1^2 - x2^2))/(2*(fx1*(x2 - x3) - fx2*(x1 - x3) + fx3*(x1 - x2)))
-    discr = -4*(fx1*(x2 - x3) - fx2*(x1 - x3) + fx3*(x1 - x2))*(fx1*x2*x3*(x2 - x3) - fx2*x1*x3*(x1 - x3) + fx3*x1*x2*(x1 - x2))/(x1^2*x2 - x1^2*x3 - x1*x2^2 + x1*x3^2 + x2^2*x3 - x2*x3^2)^2 + (-fx1*(x2^2 - x3^2) + fx2*(x1^2 - x3^2) - fx3*(x1^2 - x2^2))^2/(x1^2*x2 - x1^2*x3 - x1*x2^2 + x1*x3^2 + x2^2*x3 - x2*x3^2)^2
-
-    if discr > zero(discr)
-        b = (-fx1*(x2^2 - x3^2) + fx2*(x1^2 - x3^2) - fx3*(x1^2 - x2^2))/(x1^2*x2 - x1^2*x3 - x1*x2^2 + x1*x3^2 + x2^2*x3 - x2*x3^2)
-        a = (fx1*(x2 - x3) - fx2*(x1 - x3) + fx3*(x1 - x2))/(x1^2*x2 - x1^2*x3 - x1*x2^2 + x1*x3^2 + x2^2*x3 - x2*x3^2)
-        gamma1, gamma2 = (-b + sqrt(discr))/2a, (-b - sqrt(discr))/2a
-
-        xbar = (x1+x2+x3)/3
-        d1,d2,d3 = abs(gamma1 - xbar), abs(gamma2-xbar), abs(vertex - xbar)
-        # return closest
-        d1 < min(d2,d3) && return gamma1
-        d2 < min(d1,d3) && return gamma2
-    end
     return vertex
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,7 +65,7 @@ function guarded_secant_step(alpha, beta, falpha, fbeta)
     end
 end
 
-# return vertex of parabolar through (a,fa),(b,fb),(c,fc)
+# return vertex of parabola through (a,fa),(b,fb),(c,fc)
 # first time trhough, we have picture of a > b > c; |fa|, |fc| > |fb|, all same sign
 function quad_vertex(c,fc,b,fb,a,fa)
     fba = (fb-fa)/(b-a)

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -280,7 +280,7 @@ end
 test_94()
 
 ## Issue with quad step in Order0 being off
-@test find_zero(f, 7.36842 , Order0()) ≈ 7.068582745628732
+@test find_zero(x -> tanh(x) - tan(x), 7.36842 , Order0()) ≈ 7.068582745628732
 
 
 @testset "init_state!" begin

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -133,7 +133,7 @@ galadino_probs = [(x -> x^3 - 1, [.5, 1.5]),
                   (x -> 11x^11 - 1, [0.1, 1]),
                   (x ->  x^3 + 1, [-1.8, 0]),
                   (x ->  x^3 - 2x - 5, [2.0, 3]),
-                  
+
                   ((x,n=5)  -> 2x * exp(-n) + 1 - 2exp(-n*x) , [0,1]),
                   ((x,n=10) -> 2x * exp(-n) + 1 - 2exp(-n*x) , [0,1]),
                   ((x,n=20) -> 2x * exp(-n) + 1 - 2exp(-n*x) , [0,1]),
@@ -158,7 +158,7 @@ galadino_probs = [(x -> x^3 - 1, [.5, 1.5]),
                   ((x,n=10) -> x^2 + sin(x/n) - 1/4 , [0,1]),
                   ((x,n=10) -> x^2 + sin(x/n) - 1/4 , [0,1])
                   ]
-        
+
 
 for (fn_, ab) in galadino_probs
     for m in [Roots.A42(), Bisection(), (FalsePosition(i) for i in 1:12)...]
@@ -177,7 +177,7 @@ end
 
 ## defaults for method argument
 @test find_zero(x -> cbrt(x), 1) ≈ 0.0 # order0()
-@test find_zero(sin, [3,4]) ≈ π   # Bisection() 
+@test find_zero(sin, [3,4]) ≈ π   # Bisection()
 
 
 ## Callable objects
@@ -206,17 +206,17 @@ fn, xstar = x -> sin(x) - x + 1, 1.9345632107520243
 @test find_zero(fn, 20.0, Order2())  ≈ xstar   # needs 16 iterations, 33 fn evaluations
 @test abs(fn(find_zero(fn, 20.0, Order2(), atol=1e-2)) - xstar) > 1e-12
 @test abs(fn(find_zero(fn, 20.0, Order2(), rtol=1e-2)) - xstar) > 1e-12
-@test_throws Roots.ConvergenceFailed find_zero(fn, 20.0, Order2(), maxevals=5) 
-@test_throws Roots.ConvergenceFailed find_zero(fn, 20.0, Order2(), maxfnevals=10) 
+@test_throws Roots.ConvergenceFailed find_zero(fn, 20.0, Order2(), maxevals=5)
+@test_throws Roots.ConvergenceFailed find_zero(fn, 20.0, Order2(), maxfnevals=10)
 
 
 ## test robustness of Order0
 ## tests from: http://people.sc.fsu.edu/~jburkardt/cpp_src/test_zero/test_zero.html
-function _newton_baffler(x) 
-    if ( x - 0.0 ) < -0.25 
-        0.75 * ( x - 0 ) - 0.3125 
-    elseif  ( x - 0 ) < 0.25 
-        2.0 * ( x - 0 ) 
+function _newton_baffler(x)
+    if ( x - 0.0 ) < -0.25
+        0.75 * ( x - 0 ) - 0.3125
+    elseif  ( x - 0 ) < 0.25
+        2.0 * ( x - 0 )
     else
         0.75 * ( x - 0 ) + 0.3125
     end
@@ -227,23 +227,23 @@ pathological = [
                 (x -> x * exp( - x ), 0.99),
                 (x -> exp( x ) - 1 / ( 10 * x )^2, .1),
                 (x -> ( x + 3 ) * ( x - 1 )^2, 1),
-                
+
                 (x -> exp( x ) - 2 - 1 / ( 10 * x )^2 + 2 / ( 100 * x )^3, 1),
                 (x -> cbrt(x), 1),
                 (x -> cos( x ) - x, 1),
                 (x-> _newton_baffler(x), 8),
-                (x -> 20.0 * x / ( 100.0 * x^2 + 1.0), 0.095), 
-                
+                (x -> 20.0 * x / ( 100.0 * x^2 + 1.0), 0.095),
+
                 (x ->  ( 4.0 + x^2) * ( 2.0 + x ) * ( 2.0 - x )  / ( 16.0 * x * x * x * x + 0.00001 ), 1),
                 (x -> (x == 1.0) ? float(0) : sign(x-1.0) * exp(log(1e4) + log(abs(x - 1.0)) - 1.0/(x-1.0)^2), 1),
                 (x -> 0.00000000001 * (x - 100.0), 1),
                 (x -> 1.0 / ( ( x - 0.3 ) * ( x - 0.3 ) + 0.01 ) + 1.0 / ( ( x - 0.9 ) * ( x - 0.9 ) + 0.04 ) + 2.0 * x - 5.2, -1),
-                (x -> ( 1 - 6x^2) * cbrt(x) * exp(-x^2) / (3*x), -0.25), 
-                
+                (x -> ( 1 - 6x^2) * cbrt(x) * exp(-x^2) / (3*x), -0.25),
+
                 (x -> ( pi * ( x - 5.0 ) / 180.0 ) - 0.8 * sin( pi * x / 180.0 ), 1),
                 (x -> x^3 - 2*x - 5, 2),
 (x -> 1e6 * (x^7 -7x^6 +21x^5 -35x^4 +35x^3-21x^2+7x-1),  0.990),
-(x -> cos(100*x)-4*erf(30*x-10), 0.0) 
+(x -> cos(100*x)-4*erf(30*x-10), 0.0)
                 ]
 
 
@@ -278,6 +278,10 @@ test_94 = function(;kwargs...)
     @test state.steps <= 15
 end
 test_94()
+
+## Issue with quad step in Order0 being off
+@test find_zero(f, 7.36842 , Order0()) ≈ 7.068582745628732
+
 
 @testset "init_state!" begin
     ## add init_state! method
@@ -328,11 +332,6 @@ test_94()
         @test Roots.init_options!(options, M) == nothing
         @test Roots.update_state(M, g1, state, options)  == nothing
         @test Roots.assess_convergence(M, state, options) == false  # none in 1 step
-    end  
-    
-end
-    
-    
-    
-    
+    end
 
+end


### PR DESCRIPTION
Minor adjustment to the quad step used in Order0 when vertex of parabola would yield a sign change. The previous case was susceptible to floating point issues.