### PR TITLE
Allow passing of single function to Newton, Halley; closes #143

### DIFF
--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -325,17 +325,21 @@ e.g., define `D(f) = x->ForwardDiff.derivative(f, float(x))`, then use `D(D(f))`
 (F::FirstDerivative)(x::Number, ::Type{Val{2}}) =  error(error_msg_d2)
 (F::SecondDerivative)(x::Number, ::Type{Val{2}}) = F.fpp(x)
 
-## Return f, f'
-fdf(F::DerivativeFree, x) = error("No derivative defined")
-fdf(F::FirstDerivative,x) = (F.f(x), F.fp(x))
-fdf(F::SecondDerivative,x) = (F.f(x),F.fp(x))
+## Return f, f/f'
+fΔf(F::DerivativeFree, x) = error("No derivative defined")
+function fΔf(F::Union{FirstDerivative, SecondDerivative},x)
+    fx, fpx = F.f(x), F.fp(x)
+    fx, fx/fpx
+end
+fΔf(F::CallableFunctions, x) = F.f(x)
 
-fdfddf(F::DerivativeFree, x) = error("No first or second derivative defined")
-fdfddf(F::FirstDerivative, x) = error("No second derivative defined")
-fdfddf(F::SecondDerivative, x) = (F.f(x), F.fp(x), F.fpp(x))
-
-fdf(F::CallableFunctions, x) = F.f(x)
-fdfddf(F::CallableFunctions, x) = F.f(x)
+# return f, f/f', f''/f'
+fΔfΔΔf(F::Union{DerivativeFree, FirstDerivative}, x) = error("no second derivative defined")
+function fΔfΔΔf(F::SecondDerivative, x)
+    fx, fp, fpp = F.f(x), F.fp(x), F.fpp(x)
+    (fx, fx/fp, fpp/fp)
+end
+fΔfΔΔf(F::CallableFunctions, x) = F.f(x)
 
 
 ## Assess convergence

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -58,7 +58,7 @@ end
 function update_state(method::Newton, fs, o::UnivariateZeroState{T,S}, options) where {T, S}
     xn = o.xn1
     fxn = o.fxn1
-    Δxn::S = o.m[1]
+    Δxn::T = o.m[1]
 
     if isissue(Δxn)
         o.stopped=true

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -81,7 +81,7 @@ function update_state(method::Newton, fs, o::UnivariateZeroState{T,S}, options) 
 end
 
 """
-    newton(f, fp, x0; kwargs...)
+    Roots.newton(f, fp, x0; kwargs...)
 
 Implementation of Newton's method: `x_n1 = x_n - f(x_n)/ f'(x_n)`
 
@@ -98,7 +98,7 @@ With the `FowardDiff` package derivatives may be computed automatically. For exa
 
 Keyword arguments are passed to `find_zero` using the `Roots.Newton()` method.
 
-See also `newton((f,fp), x0) and `newton(fΔf, x0)` for simpler implementations.
+See also `Roots.newton((f,fp), x0) and `Roots.newton(fΔf, x0)` for simpler implementations.
 
 """
 newton(f, fp, x0; kwargs...) = find_zero((f, fp), x0, Newton(); kwargs...)
@@ -176,9 +176,9 @@ function update_state(method::Halley, fs, o::UnivariateZeroState{T,S}, options::
 end
 
 """
-    halley(f, fp, fpp, x0; kwargs...)
+    Roots.halley(f, fp, fpp, x0; kwargs...)
 
-Implementation of Halley's method. `xn1 = xn - 2f(xn)*f'(xn) / (2*f'(xn)^2 - f(xn) * f''(xn))`
+Implementation of Halley's method (cf `?Roots.Halley()`).
 
 Arguments:
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -171,7 +171,7 @@ function update_state(method::Halley, fs, o::UnivariateZeroState{T,S}, options::
     incfn(o,3)
 
     o.xn0, o.xn1 = xn, xn1
-    o.fxn0, o.fxn1 = fxn, fxn # lag one
+    o.fxn0, o.fxn1 = fxn, fxn1
     empty!(o.m); append!(o.m, (Δxn1, ΔΔxn1))
 end
 

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -23,8 +23,8 @@ Roots.newton(sin, cos, 3.0) ≈ π # uses find_zero
 Roots.newton((sin,cos), 3.0) ≈ π # uses simple
 
 fdf = x -> (sin(x), sin(x)/cos(x))  # (f, f/f')
-Roots.find_zero(Roots.fg(fdf), 3.0, Roots.Newton())  ≈ π # uses find_zero
+@test Roots.find_zero(Roots.fg(fdf), 3.0, Roots.Newton())  ≈ π # uses find_zero
 Roots.newton(fdf, 3.0)  ≈ π # uses simple
 
 fdfdf = x -> (sin(x), sin(x)/cos(x), -sin(x)/cos(x))   # (f, f/f', f''/f')
-Roots.find_zero(Roots.fg(fdfdf), 3.0, Roots.Halley())
+@test Roots.find_zero(Roots.fg(fdfdf), 3.0, Roots.Halley()) ≈ π

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -26,5 +26,5 @@ fdf = x -> (sin(x), sin(x)/cos(x))  # (f, f/f')
 @test Roots.find_zero(Roots.fg(fdf), 3.0, Roots.Newton())  ≈ π # uses find_zero
 Roots.newton(fdf, 3.0)  ≈ π # uses simple
 
-fdfdf = x -> (sin(x), sin(x)/cos(x), -sin(x)/cos(x))   # (f, f/f', f''/f')
+fdfdf = x -> (sin(x), sin(x)/cos(x), -cos(x)/sin(x))   # (f, f/f', f'/f'')
 @test Roots.find_zero(Roots.fg(fdfdf), 3.0, Roots.Halley()) ≈ π

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -2,7 +2,7 @@ using Compat.Test
 import Roots.newton, Roots.halley
 
 @test abs(newton(sin, cos, 0.5) - 0.0) <= 100*eps(1.0)
-@test newton(cos, x -> -sin(x), 1.0)  ≈ pi/2 
+@test newton(cos, x -> -sin(x), 1.0)  ≈ pi/2
 @test newton(x -> x^2 - 2x - 1, x -> 2x - 2, 3.0)  ≈ 2.414213562373095
 @test abs(newton(x -> exp(x) - cos(x), x -> exp(x) + sin(x), 3.0) - 0.0) <= 1e-14
 @test halley(x -> x^2 - 2x - 1,x -> 2x - 2,x -> 2, 3.0)  ≈ 2.414213562373095
@@ -15,5 +15,16 @@ a = halley(x -> exp(x) - cos(x),
 
 ## test with Complex input
 
-@test real(newton(x ->  x^3 - 1, x ->  3x^2, 1+im)) ≈ 1.0
-@test real(newton(x ->  x^3 - 1, x ->  3x^2, 1+10im)) ≈ (-1/2)
+@test real(Roots.newton(x ->  x^3 - 1, x ->  3x^2, 1+im)) ≈ 1.0
+@test real(Roots.newton(x ->  x^3 - 1, x ->  3x^2, 1+10im)) ≈ (-1/2)
+
+## Issue #143 test with new interface
+Roots.newton(sin, cos, 3.0) ≈ π # uses find_zero
+Roots.newton((sin,cos), 3.0) ≈ π # uses simple
+
+fdf = x -> (sin(x), sin(x)/cos(x))  # (f, f/f')
+Roots.find_zero(Roots.fg(fdf), 3.0, Roots.Newton())  ≈ π # uses find_zero
+Roots.newton(fdf, 3.0)  ≈ π # uses simple
+
+fdfdf = x -> (sin(x), sin(x)/cos(x), -sin(x)/cos(x))   # (f, f/f', f''/f')
+Roots.find_zero(Roots.fg(fdfdf), 3.0, Roots.Halley())


### PR DESCRIPTION
This allows one to pass in a function to `Newton` and `Halley` that computes both `f` and `f/fp` (and `fp/fpp` for Halley) at the same time. There are cases where the derivative is easy to compute from the function value, and this allows that to exploited.

* also, adds a `newton` function to the "simple" functions
* improves default `Newton()` and `Halley()` methods, which had a type instability