### PR TITLE
Fdf redux

### DIFF
--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -70,7 +70,8 @@ function find_zero(fs, x0, method::Order0;
                    kwargs...)
     M = Order1()
     N = AlefeldPotraShi()
-    _find_zero(fs, x0, M, N; tracks=tracks,verbose=verbose, kwargs...)
+
+    _find_zero(callable_function(fs), x0, M, N; tracks=tracks,verbose=verbose, kwargs...)
 end
 
 ##################################################

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -175,7 +175,7 @@ struct Order5 <: AbstractUnivariateZeroMethod end
 
 
 ## If we have a derivative, we have this. (Deprecate?)
-function update_state(method::Order5, fs::Union{FirstDerivative,SecondDerivative, CallableFunctions},
+function update_state(method::Order5, fs::Union{FirstDerivative,SecondDerivative},
                       o::UnivariateZeroState{T,S}, options)  where {T, S}
 
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -20,7 +20,7 @@ find_zero((sin,cos), 3.0, Roots.Newton())
 If function evaluations are expensive one can pass in a function which returns (f, f/f') as follows
 
 ```
-find_zero(Roots.fg(x -> (sin(x), sin(x)/cos(x))), 3.0, Roots.Newton())
+find_zero(x -> (sin(x), sin(x)/cos(x)), 3.0, Roots.Newton())
 ```
 
 This can be advantageous if the derivative is easily computed from the
@@ -124,7 +124,7 @@ If function evaluations are expensive one can pass in a function which
 returns (f, f/f',f'/f'') as follows
 
 ```
-find_zero(Roots.fgh(x -> (sin(x), sin(x)/cos(x), -cos(x)/sin(x))), 3.0, Roots.Halley())
+find_zero(x -> (sin(x), sin(x)/cos(x), -cos(x)/sin(x)), 3.0, Roots.Halley())
 ```
 
 This can be advantageous if the derivatives are easily computed from

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -34,7 +34,10 @@ function init_state(method::Newton, fs, x)
 
     x1 = float(x)
     T = eltype(x1)
-    fx1, Δ::T = fΔx(fs, x1)
+    #fx1, Δ::T = fΔx(fs, x1)
+    tmp = fΔx(fs, x1)
+    fx1, Δ::T = tmp[1], tmp[2]
+
     fnevals = 1
     S = eltype(fx1)
 
@@ -48,7 +51,8 @@ end
 
 function init_state!(state::UnivariateZeroState{T,S}, M::Newton, fs, x) where {T,S}
     x1::T = float(x)
-    fx1::S, Δ::T = fΔx(fs, x)
+    tmp = fΔx(fs, x)
+    fx1::S, Δ::T = tmp[1],tmp[2]
 
      init_state!(state, x1, oneunit(x1) * (0*x1)/(0*x1), [Δ],
                 fx1, oneunit(fx1) * (0*fx1)/(0*fx1), S[])
@@ -139,7 +143,8 @@ function init_state(method::Halley, fs, x)
 
     x1 = float(x)
     T = eltype(x1)
-    fx1, Δ::T, ΔΔ::T = fΔxΔΔx(fs, x1)
+    tmp = fΔxΔΔx(fs, x1)
+    fx1, Δ::T, ΔΔ::T = tmp[1], tmp[2], tmp[3]
     S = eltype(fx1)
     fnevals = 3
 
@@ -153,7 +158,8 @@ end
 
 function init_state!(state::UnivariateZeroState{T,S}, M::Halley, fs, x) where {T,S}
     x1::T = float(x)
-    fx1::S, Δ::T, ΔΔ::T = fΔxΔΔx(fs, x)
+    tmp = fΔxΔΔx(fs, x)
+    fx1::S, Δ::T, ΔΔ::T = tmp[1],tmp[2], tmp[3]
 
      init_state!(state, x1, oneunit(x1) * (0*x1)/(0*x1), [Δ],
                 fx1, oneunit(fx1) * (0*fx1)/(0*fx1), S[])

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -23,8 +23,8 @@ Roots.newton(sin, cos, 3.0) ≈ π # uses find_zero
 Roots.newton((sin,cos), 3.0) ≈ π # uses simple
 
 fdf = x -> (sin(x), sin(x)/cos(x))  # (f, f/f')
-@test Roots.find_zero(Roots.fg(fdf), 3.0, Roots.Newton())  ≈ π # uses find_zero
+@test Roots.find_zero(fdf, 3.0, Roots.Newton())  ≈ π # uses find_zero
 Roots.newton(fdf, 3.0)  ≈ π # uses simple
 
 fdfdf = x -> (sin(x), sin(x)/cos(x), -cos(x)/sin(x))   # (f, f/f', f'/f'')
-@test Roots.find_zero(Roots.fg(fdfdf), 3.0, Roots.Halley()) ≈ π
+@test Roots.find_zero(fdfdf, 3.0, Roots.Halley()) ≈ π

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -28,3 +28,13 @@ Roots.newton(fdf, 3.0)  ≈ π # uses simple
 
 fdfdf = x -> (sin(x), sin(x)/cos(x), -cos(x)/sin(x))   # (f, f/f', f'/f'')
 @test Roots.find_zero(fdfdf, 3.0, Roots.Halley()) ≈ π
+
+# check that functions with multiple return values can work with other
+# methods
+for M in [Roots.Halley(), Roots.Newton(), Roots.Order1(), Roots.Order0()]
+    @test Roots.find_zero(fdfdf, 3.0, M) ≈ π  # can pass function to others
+end
+for M in [Roots.Bisection(), Roots.A42(), Roots.AlefeldPotraShi()]
+    @test Roots.find_zero(fdfdf, (3.0, 4.0), M) ≈ π  # can pass function to others
+end
+@test find_zero(x -> (x^2 -2, (x^2-2)/2x), 1.0, Roots.Newton(), Roots.Bisection()) ≈ sqrt(2)


### PR DESCRIPTION
Clean up fix for issue #143:

* drops needing to wrap functions which return (f, f/df, [df/ddf]) to pass to `find_zero`. (There are potential savings in computing f and df at the same time. So all these should work

```
function fdfs(x)
  u,v = sincos(x)
  (u, u/v, -v/u)
end
[find_zero(fdfs, 3.0, M) for M in [Roots.Halley(), Roots.Newton(), Roots.Order0(), Roots.Order1()]]
```