### PR TITLE
Differentiate find_zero and fzero

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+CHANGES in v0.7.4
+
+* set find_zero(s) to specialize on the function, fzero(s) to not. (#148)
+* adjust Steffensen method logic to take secant step or steffensen
+  step, rather than modified steffensen step. Seems to improve
+  robustness. (#147)
+* add Schroder method (order 2 for multiplicity with derivative), King (1B)
+  (superlinear for multiplicity, no derivative), Esser (2B) (order 2
+  for multipicity, no derivative) (#143, #147)
+* close issue #143 by allowing fns to Newton, Halley to compute f, f/fp, fp/fpp
+* add `newton` function to simple.jl
+* change find_zeros to identify zeros on [a,b], not (a,b). Closes #141.
+* bug fix: issue with quad step after a truncated M-step in find_zero(M,N,...)
+* bug fix: verbose argument for Bisection method (#139)
+* bug fix: unintentional widening of types in intial secant step (#139)
+
 CHANGES in v0.7.3
 
 * fix bug with find_zeros and Float32

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -71,7 +71,7 @@ function find_zero(fs, x0, method::Order0;
     M = Order1()
     N = AlefeldPotraShi()
 
-    _find_zero(callable_function(fs), x0, M, N; tracks=tracks,verbose=verbose, kwargs...)
+    find_zero(callable_function(fs), x0, M, N; tracks=tracks,verbose=verbose, kwargs...)
 end
 
 ##################################################

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -292,11 +292,11 @@ fΔxΔΔx(F, x) = F(x)
 
 # allows override for function, if desired
 # the default for this specializes on the function passed
-# in. When specializatoin occurs there is overhead due to compilation
+# in. When specialization occurs there is overhead due to compilation
 # costs which can be amortized over subsequent calls to `find_zero`.
 # However, if a function is only used once, then using `fzero` will be
 # faster. (The difference is clear between `@time` and `@btime` to measure
-# speed)
+# execution time)
 #                 first call    subsequent calls  default for
 # specialize       slower         faster          find_zero
 # no specialize    faster         slower          fzero
@@ -523,23 +523,6 @@ function find_zero(fs, x0, method::AbstractUnivariateZeroMethod,
                    kwargs...)
 
     F = callable_function(fs)
-
-    _find_zero(F, x0, method, N; tracks=tracks, verbose=verbose, kwargs...)
-end
-
-## This allows for bypassing of `callable_function`.  With
-## callable_function there is no specialization on the function. This
-## makes the first call faster, but subsequent calls slower, due to
-## type instability. Without callable_function the first usage is
-## slower, though this can be effectively reduced using
-## `FunctionWrappers`.
-function _find_zero(F, x0, method::AbstractUnivariateZeroMethod,
-                    N::Union{Nothing, AbstractBracketing}=nothing;
-                    tracks::AbstractTracks=NullTracks(),
-                    verbose=false,
-                    kwargs...)
-
-
     state = init_state(method, F, x0)
     options = init_options(method, state; kwargs...)
 

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -76,7 +76,7 @@ end
 function fzero(f, bracket::Tuple{T,S}; kwargs...)  where {T <: Number, S<:Number}
     d = Dict(kwargs)
     if haskey(d, :order)
-        find_zero(FnWrapper(f), bracket, _method_lookup[order]; kwargs...)
+        find_zero(FnWrapper(f), bracket, _method_lookup[d[:order]]; kwargs...)
     else
         find_zero(FnWrapper(f), bracket, Bisection();kwargs...)
     end

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -7,13 +7,56 @@
 
 """
     fzero(f, x0; order=0; kwargs...)
+    fzero(f, x0, M; kwargs...)
+    fzero(f, x0, M, N; kwargs...)
+    fzero(f, x0; kwargs...)
+    fzero(f, a::Number, b::Numbers; kwargs...)
+    fzero(f, a::Number, b::Numbers; order=?, kwargs...)
+    fzero(f, fp, a::Number; kwargs...)
 
-Find zero of a function using an iterative algorithm
+Find zero of a function using one of several iterative algorithms.
 
 * `f`: a scalar function or callable object
-* `x0`: an initial guess, finite valued.
+
+* `x0`: an initial guess, a scalar value or tuple of two values
+
 * `order`: An integer, symbol, or string indicating the algorithm to
-   use. The default is `Order0`.
+   use for `find_zero`. The `Order0` default may be specified directly
+   by `order=0`, `order=:0`, or `order="0"`; `Order1()` by `order=1`,
+   `order=:1`, `order="1"`, or `order=:secant`; `Order1B()` by
+   `order="1B", etc.
+
+* `M`: a specific method, as would be passed to `find_zero`, bypassing
+  the use of the `order` keyword
+
+* `N`: a specific bracketing method. When given, if a bracket is
+  identified, method `N` will be used to finish instead of method `M`.
+
+* `a`, `b`: When two values are passed along, if no `order` value is
+  specified, `Bisection` will be used over the bracketing interval
+  `(a,b)`. If an `order` value is specified, the value of `x0` will be set to
+  `(a,b)` and the specified method will be used.
+
+* `fp`: when `fp` is specified (assumed to compute the derivative of `f`),
+  Newton's method will be used
+
+* `kwargs...`: See `find_zero` for the specification of tolerances and other keyword arguments
+
+Examples:
+```
+fzero(sin, 3)                  # use Order0() method, the default
+fzero(sin, 3, order=:secant)   # use secant method (also just `order=1`)
+fzero(sin, 3, Roots.Order1B()) # use secant method variant for multiple roots.
+fzero(sin, 3, 4)               # use bisection method over (3,4)
+fzero(sin, 3, 4, xatol=1e-6)   # use bisection method until |x_n - x_{n-1}| <= 1e-6
+fzero(sin, 3, 3.1, order=1)    # use secant method with x_0=3.0, x_1 = 3.1
+fzero(sin, (3, 3.1), order=2)  # use Steffensen's method with x_0=3.0, x_1 = 3.1
+fzero(sin, cos, 3)             # use Newton's method
+```
+
+Note: unlike `find_zero`, `fzero` does not specialize on the type of
+the function argument. This has the advantage of making the first use
+of the function `f` faster, but subsequent uses slower.
 
 """
 function fzero(f, x0::Number; kwargs...)
@@ -22,10 +65,6 @@ function fzero(f, x0::Number; kwargs...)
     derivative_free(f, x; kwargs...)
 end
 
-
-"""
-    fzero(f, x0, M, [N]; kwargs...)
-"""
 function fzero(f, x0, M::AbstractUnivariateZeroMethod; kwargs...)
     find_zero(FnWrapper(f), x0, M; kwargs...)
 end
@@ -34,14 +73,6 @@ function fzero(f, x0, M::AbstractUnivariateZeroMethod, N::AbstractBracketing; kw
     find_zero(FnWrapper(f), x0, M, N; kwargs...)
 end
 
-"""
-    fzero(f, a, b; kwargs...)
-
-If `order` is not specified, will use bisection to find a zero of a
-function within a bracket, [a,b]. Otherwise, will use `x0=(a,b)` for
-the method specified by `order`.
-
-"""
 function fzero(f, bracket::Tuple{T,S}; kwargs...)  where {T <: Number, S<:Number}
     if haskey(kwargs, :order)
         find_zero(FnWrapper(f), bracket, _method_lookup[kwargs[:order]]; kwargs...)
@@ -54,16 +85,6 @@ fzero(f, a::Number, b::Number; kwargs...) = fzero(f, (a,b); kwargs...)
 fzero(f, bracket::Vector{T}; kwargs...)  where {T <: Number} = fzero(f,(bracket[1],bracket[2]); kwargs...)
 
 
-
-
-"""
-    fzero(f, fp, x0; kwargs)
-
-Find zero using Newton's method.
-
-Dispatches to `find_zero((f,fp), x0, Roots.Newton(); kwargs...)`.
-
-"""
 fzero(f::Function, fp::Function, x0::Real; kwargs...) = find_zero((f,fp), x0, Newton(); kwargs...)
 
 
@@ -79,15 +100,19 @@ _method_lookup = Dict(0   => Order0(),
                       :1   => Order1(),
                       "1"  => Order1(),
                       :secant => Order1(),
+                      :Secant => Order1(),
                       "1B" => Order1B(),
                       :king => Order1B(),
+                      :King => Order1B(),
 
                      2    => Order2(),
                      :2   => Order2(),
                      :steffensen   => Order2(),
+                     :Steffensen   => Order2(),
                      "2"  => Order2(),
                      "2B" => Order2B(),
                      :esser   => Order2B(),
+                     :Esser   => Order2B(),
 
                       5  => Order5(),
                      :5  => Order5(),

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -13,7 +13,7 @@ Find zero of a function using an iterative algorithm
 * `f`: a scalar function or callable object
 * `x0`: an initial guess, finite valued.
 * `order`
-    
+
 This is a polyalgorithm redirecting to different algorithms based on the value of `order`. Dispatches to `find_zero(f, x0, OrderN(); kwargs...)`.
 
 """
@@ -23,11 +23,17 @@ function fzero(f, x0::Number; kwargs...)
     derivative_free(f, x; kwargs...)
 end
 
+function fzero(f, x0, M::AbstractUnivariateZeroMethod; kwargs...)
+    find_zero(FnWrapper(f), x0, M; kwargs...)
+end
 
+function fzero(f, x0, M::AbstractUnivariateZeroMethod, N::AbstractBracketing; kwargs...)
+    find_zero(FnWrapper(f), x0, M, N; kwargs...)
+end
 
 """
     fzero(f, a, b; kwargs...)
-    
+
 Find zero of a function within a bracket, [a,b].
 
 Dispatches to `find_zero(f, (a,b), Bisection())`.
@@ -42,11 +48,11 @@ fzero(f, bracket::Tuple{T,S}; kwargs...)  where {T <: Number, S<:Number} = find_
 
 """
     fzero(f, fp, x0; kwargs)
-    
+
 Find zero using Newton's method.
 
 Dispatches to `find_zero((f,fp), x0, Roots.Newton(); kwargs...)`.
-    
+
 """
 fzero(f::Function, fp::Function, x0::Real; kwargs...) = newton(f, fp, float(x0); kwargs...)
 
@@ -56,8 +62,8 @@ fzero(f::Function, fp::Function, x0::Real; kwargs...) = newton(f, fp, float(x0);
 
 
 # match fzero up with find_zero
-@noinline function derivative_free(f, x0; order::Int=0, kwargs...) 
-    
+@noinline function derivative_free(f, x0; order::Int=0, kwargs...)
+
     if order == 0
         method = Order0()
     elseif order == 1
@@ -84,19 +90,19 @@ fzero(f::Function, fp::Function, x0::Real; kwargs...) = newton(f, fp, float(x0);
     end
 
 
-    
-    find_zero(f, x0, method; d...)
+
+    find_zero(FnWrapper(f), x0, method; d...)
 end
 
 
-# ## 
+# ##
 # """
 #     fzero(f, x0, bracket; kwargs...)
-#    
+#
 # Find a zero within a bracket with an initial guess to *possibly* speed things along.
 #
 # Dispatches to the `A42` method.
-#    
+#
 #"""
 @deprecate fzero(f, x0::Real, bracket::Vector; kwargs...)  fzero(f, bracket)
 
@@ -107,14 +113,13 @@ end
 """
 
 `fzeros(f, a, b; kwargs...)`
-    
+
 Searches for all zeros of `f` within an interval `(a,b)`. Assume neither `a` or `b` is a zero.
 
 Dispatches to `find_zeros(f, a, b; kwargs...)`.
-"""        
-function fzeros(f, a::Number, b::Number; kwargs...)  
+"""
+function fzeros(f, a::Number, b::Number; kwargs...)
     find_zeros(f, float(a), float(b); kwargs...)
 end
 fzeros(f, bracket::Vector{T}; kwargs...) where {T <: Number} = fzeros(f, a, b; kwargs...)
-fzeros(f, bracket::Tuple{T,S}; kwargs...) where {T <: Number, S<:Number} = fzeros(f, a, b; kwargs...) 
-
+fzeros(f, bracket::Tuple{T,S}; kwargs...) where {T <: Number, S<:Number} = fzeros(f, a, b; kwargs...)

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -44,7 +44,7 @@ the method specified by `order`.
 """
 function fzero(f, bracket::Tuple{T,S}; kwargs...)  where {T <: Number, S<:Number}
     if haskey(kwargs, :order)
-        find_zero(FnWrapper(f), bracket, _method_lookup(kwargs,:order); kwargs...)
+        find_zero(FnWrapper(f), bracket, _method_lookup[kwargs[:order]]; kwargs...)
     else
         find_zero(FnWrapper(f), bracket, Bisection();kwargs...)
     end

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -133,7 +133,7 @@ _method_lookup = Dict(0   => Order0(),
     if haskey(_method_lookup, order)
         M = _method_lookup[order]
     else
-        warn("Invalid order. Valid orders are 0, 1, 2, 5, 8, and 16")
+        warn("Invalid order specified. See ?fzero.")
         throw(ArgumentError())
     end
 

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -74,8 +74,9 @@ function fzero(f, x0, M::AbstractUnivariateZeroMethod, N::AbstractBracketing; kw
 end
 
 function fzero(f, bracket::Tuple{T,S}; kwargs...)  where {T <: Number, S<:Number}
-    if haskey(Dict(kwargs), :order)
-        find_zero(FnWrapper(f), bracket, _method_lookup[kwargs[:order]]; kwargs...)
+    d = Dict(kwargs)
+    if haskey(d, :order)
+        find_zero(FnWrapper(f), bracket, _method_lookup[order]; kwargs...)
     else
         find_zero(FnWrapper(f), bracket, Bisection();kwargs...)
     end

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -74,7 +74,7 @@ function fzero(f, x0, M::AbstractUnivariateZeroMethod, N::AbstractBracketing; kw
 end
 
 function fzero(f, bracket::Tuple{T,S}; kwargs...)  where {T <: Number, S<:Number}
-    if haskey(kwargs, :order)
+    if haskey(Dict(kwargs), :order)
         find_zero(FnWrapper(f), bracket, _method_lookup[kwargs[:order]]; kwargs...)
     else
         find_zero(FnWrapper(f), bracket, Bisection();kwargs...)

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -49,3 +49,26 @@ fn = x -> cos(10*pi*x)
 
 ### issue with fzeros and roots near 'b'
 @test 0 <  maximum(fzeros(x -> sin(x) - 1/1000*x, 0, pi)) < pi
+
+
+## Change to interface
+for o in  keys(Roots._method_lookup)
+    @test fzero(x -> x^3 - x, 0.9, order=o)  ≈ 1.0
+end
+
+for M in [Roots.Order0(), Roots.Order1(), Roots.Order1B(), Roots.Order2(), Roots.Order2B()]
+    @test fzero(x -> x^3 - x, 0.7, M)  ≈ 1.0
+end
+
+for M in [Roots.Order1(), Roots.Order1B(), Roots.Order2(), Roots.Order2B()]
+    N = Roots.Bisection()
+    @test fzero(x -> x^3 - x, 0.7, M, N)  ≈ 1.0
+end
+
+@test fzero(sin, 3)  ≈ pi # order0
+@test fzero(sin, (3,3.1), order=1)  ≈ pi # use order if specified
+@test fzero(sin, (3,4))  ≈ pi  # bracketing
+@test fzero(sin, 3, 4)  ≈ pi  # bracketing
+@test fzero(sin, [3,4])  ≈ pi  # bracketing
+@test_throws ArgumentError fzero(sin, (3,3.1)) # not a bracket
+@test fzero(sin, cos, 3)  ≈ pi # newton


### PR DESCRIPTION
This package has `find_zero` and `fzero` as alternate interfaces for historic reasons. Rather than deprecate the latter, this PR takes advantage of the two names. There can be performance differences due to function specialization or not. If there is specialization, the first time a function is used there will be additional compilation which can be amortized over subsequent uses of the function. If there is no specialization the first time a function is used may be faster, but subsequent uses slower. Either may be desirable. This PR allows both, with `find_zero` specializing on the function call and `fzero` not specializing (similarly for `find_zeros` and `fzeros`.

```
julia> @btime find_zero(sin, 3.0, Order1())
  329.372 ns (4 allocations: 320 bytes)
3.141592653589793

julia> @btime fzero(sin, 3.0, Order1())
  2.174 μs (46 allocations: 992 bytes)
3.141592653589793

julia> @time find_zero(x->sin(x), 3.0, Order1())
  0.098094 seconds (223.31 k allocations: 11.409 MiB, 3.13% gc time)
3.141592653589793

julia> @time fzero(x->sin(x), 3.0, Order1())
  0.009031 seconds (3.26 k allocations: 182.921 KiB)
3.141592653589793
```