### PR TITLE
close issue #159

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -107,6 +107,20 @@ function init_state!(state::UnivariateZeroState{T,S}, M::AbstractBisection, fs,
 
     sign(fx0) * sign(fx1) > 0 && throw(ArgumentError(bracketing_error))
 
+    if iszero(sign(fx0) * sign(fx1))
+        # should be an error -- not bracketing, but we have a zero, so return it.
+        if iszero(fx0)
+            m, fm = x0, fx0
+        else
+            m, fm = x1, fx1
+        end
+        state.f_converged = true
+        state.xn1 = m
+        state.fxn1 = fm
+        return state
+    end
+
+
     # we need a,b to be same sign, finite
     if sign(x0) * sign(x1) < 0
         m = zero(x1)

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -281,6 +281,9 @@ end
     u = find_zero(sin, (3, 4), atol=atol)
     @test atol >= abs(sin(u)) >= atol^2
 
+    ## issue #159 bracket with zeros should be found
+    @test find_zero(x->x+1,(-1,1)) == -1
+
 end
 
 


### PR DESCRIPTION
Issue #159 is about bracketing when an endpoint is a zero. Either this should be an error (a bracket isn't actually specified) or the zero should be returned. This chooses the user friendly latter for AbstractBisection.