### PR TITLE
rework to save bracket 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "0.8.4"
+version = "1.0.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-SpecialFunctions = "0.8, 0.9"
+SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "1.0"
 
 [extras]

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -515,14 +515,14 @@ end
     default_tolerances(::AbstractAlefeldPotraShi, T, S)
 
 The default tolerances for Alefeld, Potra, and Shi methods are
-`xatol=zero(T)`, `xrtol=2eps(T)`, `atol= zero(S), and rtol=zero(S)`, with
+`xatol=zero(T)`, `xrtol=eps(T)/2`, `atol= zero(S), and rtol=zero(S)`, with
 appropriate units; `maxevals=45`, `maxfnevals = Inf`; and `strict=true`.
 
 """
 default_tolerances(M::AbstractAlefeldPotraShi) = default_tolerances(M, Float64, Float64)
 function default_tolerances(::AbstractAlefeldPotraShi, ::Type{T}, ::Type{S}) where {T,S}
     xatol = zero(T)
-    xrtol = 2 * eps(one(T))
+    xrtol = eps(one(T)/2)
     atol = zero(float(one(S))) * oneunit(S)
     rtol = zero(float(one(S))) * one(S)
     maxevals = 45

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -62,7 +62,7 @@ end
 function init_state(method::AbstractSecant, fs, x::Union{Tuple, Vector})
     x0, x1 = promote(float(x[1]), float(x[2]))
     fx0, fx1 = fs(x0), fs(x1)
-    state = UnivariateZeroState(x1, x0, x1, eltype(x1)[],
+    state = UnivariateZeroState(x1, x0, zero(x1)/zero(x1)*oneunit(x1), eltype(x1)[],
                                 fx1, fx0, fx1, eltype(fx1)[],
                                 0, 2,
                                 false, false, false, false, "")

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -62,8 +62,8 @@ end
 function init_state(method::AbstractSecant, fs, x::Union{Tuple, Vector})
     x0, x1 = promote(float(x[1]), float(x[2]))
     fx0, fx1 = fs(x0), fs(x1)
-    state = UnivariateZeroState(x1, x0, eltype(x1)[],
-                                fx1, fx0, eltype(fx1)[],
+    state = UnivariateZeroState(x1, x0, x1, eltype(x1)[],
+                                fx1, fx0, fx1, eltype(fx1)[],
                                 0, 2,
                                 false, false, false, false, "")
 

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -64,7 +64,7 @@ function init_state(method::Any, fs, x)
     fx1 = fs(x1); fnevals = 1
     T, S = eltype(x1), eltype(fx1)
     zT, zS =  oneunit(x1) * (0*x1)/(0*x1), oneunit(fx1) * (0*fx1)/(0*fx1)
-    state = UnivariateZeroState(x1, zT, zT, T[],
+    state = UnivariateZeroState(x1, zT, zT/Zt*oneunit(x1), T[],
                                 fx1, zS, zS, S[],
                                 0, fnevals,
                                 false, false, false, false,
@@ -350,7 +350,9 @@ function assess_convergence(method::Any, state::UnivariateZeroState{T,S}, option
     fxn1 = state.fxn1
 
     if (state.x_converged || state.f_converged || state.stopped)
-        state.xstar, state.fxstar =  xn1, fxn1
+        if isnan(state.xstar)
+            state.xstar, state.fxstar =  xn1, fxn1
+        end
         return true
     end
 

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -39,9 +39,11 @@ abstract type  AbstractUnivariateZeroState end
 mutable struct UnivariateZeroState{T,S} <: AbstractUnivariateZeroState where {T,S}
     xn1::T
     xn0::T
+    xstar::T
     m::Vector{T}
     fxn1::S
     fxn0::S
+    fxstar::S
     fm::Vector{S}
     steps::Int
     fnevals::Int
@@ -61,9 +63,9 @@ function init_state(method::Any, fs, x)
     x1 = float(x)
     fx1 = fs(x1); fnevals = 1
     T, S = eltype(x1), eltype(fx1)
-
-    state = UnivariateZeroState(x1, oneunit(x1) * (0*x1)/(0*x1), T[],
-                                fx1, oneunit(fx1) * (0*fx1)/(0*fx1), S[],
+    zT, zS =  oneunit(x1) * (0*x1)/(0*x1), oneunit(fx1) * (0*fx1)/(0*fx1)
+    state = UnivariateZeroState(x1, zT, zT, T[],
+                                fx1, zS, zS, S[],
                                 0, fnevals,
                                 false, false, false, false,
                                 "")
@@ -112,8 +114,8 @@ end
 
 
 function Base.copy(state::UnivariateZeroState{T,S}) where {T, S}
-    UnivariateZeroState(state.xn1, state.xn0, copy(state.m),
-                        state.fxn1, state.fxn0, copy(state.fm),
+    UnivariateZeroState(state.xn1, state.xn0, state.xstar, copy(state.m),
+                        state.fxn1, state.fxn0, state.fxstar, copy(state.fm),
                         state.steps, state.fnevals,
                         state.stopped, state.x_converged,
                         state.f_converged, state.convergence_failed,
@@ -348,6 +350,7 @@ function assess_convergence(method::Any, state::UnivariateZeroState{T,S}, option
     fxn1 = state.fxn1
 
     if (state.x_converged || state.f_converged || state.stopped)
+        state.xstar, state.fxstar =  xn1, fxn1
         return true
     end
 
@@ -365,6 +368,7 @@ function assess_convergence(method::Any, state::UnivariateZeroState{T,S}, option
 
     # f(xstar) ≈ xstar * f'(xstar)*eps(), so we pass in lambda
     if _is_f_approx_0(fxn1, xn1, options.abstol, options.reltol)
+        state.xstar, state.fxstar = xn1, fxn1
         state.f_converged = true
         return true
     end
@@ -372,6 +376,7 @@ function assess_convergence(method::Any, state::UnivariateZeroState{T,S}, option
     # stop when xn1 ~ xn.
     # in find_zeros there is a check that f could be a zero with a relaxed tolerance
     if abs(xn1 - xn0) < max(options.xabstol, max(abs(xn1), abs(xn0)) * options.xreltol)
+        state.xstar, state.fxstar = xn1, fxn1
         state.message *= "x_n ≈ x_{n-1}. "
         state.x_converged = true
         return true
@@ -580,10 +585,22 @@ function find_zero(M::AbstractUnivariateZeroMethod,
     return decide_convergence(M, F, state, options)
 end
 
+function find_zero(M::AbstractUnivariateZeroMethod,
+                   F,
+                   state::AbstractUnivariateZeroState,
+                   l::AbstractTracks=NullTracks()
+                   )  #where {T<:Number, S<:Number}
+
+    options = init_options(M, state)
+    find_zero(M, F, options, state, l)
+end
+
+
+
 # state has stopped, this identifies if it has converged
 function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state::UnivariateZeroState{T,S}, options) where {T,S}
-    xn1 = state.xn1
-    fxn1 = state.fxn1
+    xn1 = state.xstar
+    fxn1 = state.fxstar
 
     if (state.stopped || state.x_converged) && !(state.f_converged)
         ## stopped is a heuristic, x_converged can mask issues
@@ -611,6 +628,7 @@ function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state::Univaria
         else
             xstar, fxstar = state.xn1, state.fxn1
             if _is_f_approx_0(fxstar, xstar, options.abstol, options.reltol, :relaxed)
+                state.xstar, state.fxstar = xstar, fxstar
                 msg = "Algorithm stopped early, but |f(xn)| < ϵ^(1/3), where ϵ depends on xn, rtol, and atol. "
                 state.message = state.message == "" ? msg : state.message * "\n\t" * msg
                 state.f_converged = true
@@ -621,10 +639,10 @@ function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state::Univaria
     end
 
     if state.f_converged
-        return state.xn1
+        return state.xstar
     end
 
-    nan = NaN * state.xn1
+    nan = NaN * xn1
     if state.convergence_failed
         return nan
     end
@@ -685,6 +703,7 @@ function find_zero(M::AbstractUnivariateZeroMethod,
         ## did we find a zero or a bracketing interval?
         if iszero(state0.fxn1)
             copy!(state, state0)
+            state.xstar, state.fxstar = state.xn1, state.fxn1
             state.f_converged = true
             break
         elseif sign(state0.fxn0) * sign(state0.fxn1) < 0

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -52,8 +52,9 @@ function init_state(method::AbstractNewtonLikeMethod, fs, x)
     fnevals = 1
     S = eltype(fx1)
 
-    state = UnivariateZeroState(x1, oneunit(x1) * (0*x1)/(0*x1), [Δ],
-                                fx1, oneunit(fx1) * (0*fx1)/(0*fx1), S[],
+    zT, zS = oneunit(x1) * (0*x1)/(0*x1), oneunit(fx1) * (0*fx1)/(0*fx1)
+    state = UnivariateZeroState(x1, zT, zT, [Δ],
+                                fx1, zS, zS, S[],
                                 0, fnevals,
                                 false, false, false, false,
                                 "")
@@ -163,8 +164,9 @@ function init_state(method::AbstractHalleyLikeMethod, fs, x)
     S = eltype(fx1)
     fnevals = 3
 
-    state = UnivariateZeroState(x1, oneunit(x1) * (0*x1)/(0*x1), [Δ,ΔΔ],
-                                fx1, oneunit(fx1) * (0*fx1)/(0*fx1), S[],
+    zT, zS =  oneunit(x1) * (0*x1)/(0*x1), oneunit(fx1) * (0*fx1)/(0*fx1)
+    state = UnivariateZeroState(x1, zT, zT, [Δ,ΔΔ],
+                                fx1, zS, zS, S[],
                                 0, fnevals,
                                 false, false, false, false,
                                 "")

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -53,7 +53,7 @@ function init_state(method::AbstractNewtonLikeMethod, fs, x)
     S = eltype(fx1)
 
     zT, zS = oneunit(x1) * (0*x1)/(0*x1), oneunit(fx1) * (0*fx1)/(0*fx1)
-    state = UnivariateZeroState(x1, zT, zT, [Δ],
+    state = UnivariateZeroState(x1, zT, zT/zT*oneunit(x1), [Δ],
                                 fx1, zS, zS, S[],
                                 0, fnevals,
                                 false, false, false, false,
@@ -165,7 +165,7 @@ function init_state(method::AbstractHalleyLikeMethod, fs, x)
     fnevals = 3
 
     zT, zS =  oneunit(x1) * (0*x1)/(0*x1), oneunit(fx1) * (0*fx1)/(0*fx1)
-    state = UnivariateZeroState(x1, zT, zT, [Δ,ΔΔ],
+    state = UnivariateZeroState(x1, zT, zT/zT*oneunit(x1), [Δ,ΔΔ],
                                 fx1, zS, zS, S[],
                                 0, fnevals,
                                 false, false, false, false,

--- a/test/test_bracketing.jl
+++ b/test/test_bracketing.jl
@@ -252,6 +252,13 @@ avg(x) = sum(x)/length(x)
 
 end
 
+mutable struct Cnt
+    cnt::Int
+    f
+    Cnt(f) = new(0, f)
+end
+(f::Cnt)(x) = (f.cnt += 1; f.f(x))
+
 ## Some tests for FalsePosition methods
 @testset "FalsePosition" begin
     galadino_probs = [(x -> x^3 - 1, [.5, 1.5]),

--- a/test/test_bracketing.jl
+++ b/test/test_bracketing.jl
@@ -229,6 +229,7 @@ avg(x) = sum(x)/length(x)
     ## brent has some failures
     Ms = [Roots.Brent()]
     results = [run_tests((f,b) -> find_zero(f, b, M), name="$M") for M in Ms]
+
     maxfailures = maximum([length(result.failures) for result in results])
     maxresidual = maximum([result.maxresidual for result in results])
     cnts = [result.evalcount for result in results]

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -328,4 +328,44 @@ end
         out = Roots.find_bracket(f, x0)
         @test prod(f.(out.bracket)) <= 0
     end
+
+    ## test size of  bracket
+    for M in  (Roots.BisectionExact(),  Roots.A42(), Roots.AlefeldPotraShi())
+        for (fn, b) in ((x  -> x == 0. ? 0. : x/exp(1/(x*x)), (-1.0, 4.0)),
+                        (x -> exp(-15*x)*(x-1) + x^15, (0., 1.)),
+                        (x -> (-40.0)*x*exp(-x),  (-9, 31))
+                        )
+            l =  Roots.find_bracket(fn, b, M)
+            @test  l.exact ||  abs(l.bracket[2] -  l.bracket[1])  <=  eps(l.xstar)
+        end
+    end
+
+    ## subnormal
+    x0 = nextfloat(nextfloat(0.0))
+    fn = x  ->  (x-x0)
+    b =  (0.0, 1.0)
+    m =  Roots.__middle(b...)  # 1e-154
+    M = Roots.BisectionExact()
+    l = Roots.find_bracket(fn,  b,  M)
+    ## Here l.exact=true, but  this checks the bracket size
+    @test  !(abs(-(l.bracket...)) <=  eps(l.xstar))
+    @test  abs(-(l.bracket...)) <=  m
+
+    M =  Roots.A42()
+    l = Roots.find_bracket(fn,  b,  M)
+    @test  !(abs(-(l.bracket...)) <=  eps(l.xstar))
+    @test  abs(-(l.bracket...)) <= m
+
+    M =  Roots.AlefeldPotraShi()
+    l = Roots.find_bracket(fn,  b,  M)
+    @test  !(abs(-(l.bracket...)) <=  eps(l.xstar))
+    @test  abs(-(l.bracket...)) <= m
+
+    x0 = nextfloat(0.0)
+    fn  = x ->  x <=  0.0 ?  x-x0  : x  +  x0
+    b = (-1.0, 1.0)
+    M = Roots.BisectionExact()
+    l = Roots.find_bracket(fn,  b,  M)
+    @test !l.exact &&   abs(-(l.bracket...))  <= maximum(eps.(l.bracket))
+
 end

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -317,3 +317,15 @@ end
     end
 
 end
+
+@testset "find_bracket test" begin
+    fs_xs = ((x -> x^5 - x - 1, (0,2)),
+             (sin, (3,4)),
+             (x -> exp(x) - x^4, (5, 20))
+             )
+
+    for (f, x0) in fs_xs
+        out = Roots.find_bracket(f, x0)
+        @test prod(f.(out.bracket)) <= 0
+    end
+end


### PR DESCRIPTION
Introduces `find_bracket` to return a tuple containing a zero, an enclosing bracket, and a flat indicating if the value is an exact zero.

To do so, required adding a field in the struct to store the approximate zero instead of reusing `xn1`, which contains one part of the bracket.