### PR TITLE
use the correct brackets in _fbracket_ratio

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,7 +108,7 @@ function _fbracket_ratio(a, b, c, fa, fb, fc)
     x1, _ = _fbracket(a, b, fa, fb)
     x2, _ = _fbracket(a, c, fa, fc)
     x3, _ = _fbracket(b, c, fb, fc)
-    out = (x2 * x3) / x3
+    out = (x1 * x2) / x3
     out, isissue(out)
 end
 

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -187,10 +187,10 @@ end
     ## issues with starting near a maxima. Some bounce out of it, but
     ## one would expect all to have issues
     fn, xstar = x -> x^3 + 4x^2 -10,  1.365230013414097
-    for M in [Order1(), Roots.Order1B(), Order2(), Roots.Order2B()]
+    for M in [Order1(), Roots.Order1B(), Order2(), Roots.Order2B(), Order5()]
         @test_throws Roots.ConvergenceFailed find_zero(fn, -1.0, M)
     end
-    for M in [Order0(),  Order5(), Order8(), Order16()]
+    for M in [Order0(),  Order8(), Order16()]
         @test find_zero(fn, -1.0, M) ≈ xstar
     end
 


### PR DESCRIPTION
Hello and thank you for this great library.

There is a small bug in the _fbracket_ratio method. The return variable did not match what the documentation above it said:

`## use f[a,b] * f[a,c] / f[b,c]`
....
`out = (x2 * x3) / x3`