### PR TITLE
add simple muller method

### DIFF
--- a/test/test_simple.jl
+++ b/test/test_simple.jl
@@ -21,6 +21,23 @@ using Test
     @test abs(fpoly(xrt)) <= 1e-14
 
 
+    # muller
+    fpoly(x) = x^5 - x - 1
+    xrt = Roots.muller(fpoly, 1.0)
+    @test xrt isa Real
+    @test abs(fpoly(xrt)) <= 1e-15
+
+    @test_throws DomainError Roots.muller(fpoly, -1.0)
+    xrt = Roots.muller(fpoly, -1.0+0im)
+    @test xrt isa Complex
+    @test abs(fpoly(xrt)) <= 1e-15
+
+    @test Roots.muller(cos, 1.0) ≈ π/2
+    expoly(z) = log(-z)*asin(z)/tanh(z)
+
+    @test Roots.muller(expoly, 0.2+0.5im) ≈ im*π/2
+    @test Roots.muller(expoly, -0.7-0.5im) ≈ -1.0
+    
     # dfree
     fpoly(x) = x^5 - x - 1
     xrt = Roots.dfree(fpoly, 1.0)


### PR DESCRIPTION
Please have a careful look, I'm by no means expert in numerical computation.

A few questions here as well:
* should we automatically switch to complex arithmetic, or throw an error asking the user to do so?
* please advise on `rtol` and `atol`. I just copied these from `newton` method (is there a reason to use rational exponents?? these divisions take longer than the root finding itself ;-)
* since this is a generalized secant method, it may substitute it when three values are available. It seems that one of such places is `bracketing.jl` but I don't feel competent enough 