### PR TITLE
Remove two unused variables in bracketing.jl

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -403,7 +403,6 @@ end
 # Cubic if possible, if not, quadratic(3)
 function take_a42_step(a::T, b, d, ee, fa, fb, fd, fe, k, delta=zero(T)) where {T}
 
-    fs = (fa, fb, fd, fe)
     # if r is NaN or Inf we move on by condition. Faster than checking ahead of time for
     # distinctness
     r = ipzero(a,b,d,ee, fa, fb,fd,fe, delta) # let error and see difference in allcoation?
@@ -440,7 +439,6 @@ function newton_quadratic(a::T, b, d, fa, fb, fd, k::Int, delta=zero(T)) where {
     if !(isnan(A) || isinf(A)) || !iszero(A)
         B = f_ab(a,b,fa,fb)
 
-        dr = zero(r)
         for i in 1:k
             Pr = fa + B * (r-a) +  A * (r-a)*(r-b)
             Prp = (B + A*(2r - a - b))

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -349,8 +349,7 @@ function update_state(method::Esser, fs,
                       o::UnivariateZeroState{T,S}, options)  where {T, S}
 
 
-    x0, x1 = o.xn0, o.xn1
-    fx0, fx1 = o.fxn0, o.fxn1
+    x1, fx1 = o.xn1, o.fxn1
 
     f0 = fx1
 


### PR DESCRIPTION
Hello,

found two variables that are declared but never used in their respective functions. Therefore I would assume it is safe to remove them?
The jit-compiler probably already removes them before compiling, so it should not impact performance, just make the code a little cleaner.