### PR TITLE
add ZeroProblem interface; close #196

### DIFF
--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -10,7 +10,7 @@ export fzero,
        fzeros,
        secant_method
 
-export find_zero, find_zeros,
+export find_zero, find_zero!, find_zeros,
        Order0, Order1, Order2, Order5, Order8, Order16
 
 export Bisection, FalsePosition

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -214,6 +214,7 @@ abstract type AbstractTracks end
 struct NullTracks <: AbstractTracks end
 # api
 log_step(s::NullTracks, M, x, init=false) = nothing
+log_step(::Nothing, M, x, init=false) = nothing
 
 mutable struct Tracks{T,S} <: AbstractTracks
 xs::Vector{T}
@@ -711,113 +712,7 @@ function find_zero(M::AbstractUnivariateZeroMethod,
 end
 
 
-# An alternate interface
-struct ZeroProblem{M,F,S,O,L}
-    M::M
-    F::F
-    state::S
-    options::O
-    logger::L
-end
-
-"""
-    ZeroProblem(M, fs, x0; verbose=false, kwargs...)
-
-Setup a problem for solution. Call `find_zero!` to solve.
-
-* `M`: Method. A non-hybrid method (not `Order0`).
-* `fs`: a function or for some methods a tuple of functions
-* `x0`: the initial guess
-* `verbose`: if `true`, then calling `Roots.tracks` on the output will show the steps on the algorithm
-* `kwargs`: passed to `Roots.init_options` to adjust tolerances
-"""
-function ZeroProblem(M::AbstractUnivariateZeroMethod,
-                     fs,
-                     x0;
-                     verbose=false,
-                     kwargs...)
-    
-    F = callable_function(fs)
-    state = init_state(M, F, x0)
-    options = init_options(M, state; kwargs...)
-    l = verbose ? Tracks(eltype(state.xn1)[], eltype(state.fxn1)[]) : NullTracks()
-
-    ZeroProblem(M,F,state, options, l)
-    
-end
-
-# Iteration interface just for fun
-function Base.iterate(P::ZeroProblem, state=nothing)
-    state == true && return nothing
-    
-    M, F, state, options, l = P.M, P.F, P.state, P.options, P.logger
-
-    if state != nothing
-        update_state(M, F, state, options)
-        log_step(l, M, state)
-        incsteps(state)
-    end
-    
-    val = assess_convergence(M, state, options) 
-    val ? (decide_convergence(M, F, state, options), val) : (state.xn1, val)
-    
-end
-
-
-
-
-"""
-    tracks(P::ZeroProblem)
-
-Show trace of output when `verbose=true` is specified to the problem
-"""
-function tracks(P::ZeroProblem{M,F,S,O,L}) where {M,F,S,O,L<:Tracks}
-    show_trace(P.M, nothing, P.state, P.logger)
-end
-
-"""
-    find_zero!(P::ZeroProblem)
-
-An alternate interface whereby a problem is created with `ZeroProblem` and solved
-with `find_zero`. 
-
-Returns `NaN`, not an error, when the problem can not be solved.
-
-Advantages are the `solve` object is accessible after solving.
-
-```jldoctest find_zero!
-julia> P = Roots.ZeroProblem(Order1(), sin, 3, verbose=true); 
-
-julia> find_zero!(P)
-3.141592653589793
-
-julia> P.state.xstar
-3.141592653589793
-
-julia> Roots.tracks(P)
-Results of univariate zero finding:
-
-* Converged to: 3.141592653589793
-* Algorithm: Roots.Secant()
-* iterations: 4
-* function evaluations: 6
-* stopped as |f(x_n)| ≤ max(δ, max(1,|x|)⋅ϵ) using δ = atol, ϵ = rtol
-
-Trace:
-x_0 =  3.0000000000000000,	 fx_0 =  0.1411200080598672
-x_1 =  3.1425464815525403,	 fx_1 = -0.0009538278181169
-x_2 =  3.1415894805773834,	 fx_2 =  0.0000031730124098
-x_3 =  3.1415926535902727,	 fx_3 = -0.0000000000004795
-x_4 =  3.1415926535897931,	 fx_4 =  0.0000000000000001
-```
-
-"""
-function find_zero!(P::ZeroProblem)
-    for _ in P end
-    decide_convergence(P.M, P.F, P.state, P.options)
-end
-
-
+## --
 
 # state has stopped, this identifies if it has converged
 function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state::UnivariateZeroState{T,S}, options) where {T,S}
@@ -1006,4 +901,116 @@ function find_zero(M::AbstractUnivariateZeroMethod,
     end
 
     decide_convergence(M, F, state, options)
+end
+
+
+
+
+# An alternate interface
+# create a problem, call find_zero!
+# returns NaN, not an error, if there are issues
+struct ZeroProblem{M,F,S,O,L}
+    M::M
+    F::F
+    state::S
+    options::O
+    logger::L
+end
+
+"""
+    ZeroProblem(M, fs, x0; verbose=false, kwargs...)
+
+Setup a problem for solution. Call `find_zero!` to solve.
+
+* `M`: Method. A non-hybrid method (not `Order0`).
+* `fs`: a function or for some methods a tuple of functions
+* `x0`: the initial guess
+* `verbose`: if `true`, then calling `Roots.tracks` on the output will show the steps on the algorithm
+* `kwargs`: passed to `Roots.init_options` to adjust tolerances
+"""
+function ZeroProblem(M::AbstractUnivariateZeroMethod,
+                     fs,
+                     x0;
+                     verbose=false,
+                     kwargs...)
+
+    F = callable_function(fs)
+    state = init_state(M, F, x0)
+    options = init_options(M, state; kwargs...)
+    l = verbose ? Tracks(eltype(state.xn1)[], eltype(state.fxn1)[]) : nothing
+
+    ZeroProblem(M,F,state, options, l)
+
+end
+
+# Iteration interface to handle looping
+function Base.iterate(P::ZeroProblem, state=nothing)
+
+    M, F, state, options, l = P.M, P.F, P.state, P.options, P.logger
+    assess_convergence(M, state, options)  && return  nothing
+
+    update_state(M, F, state, options)
+    log_step(l, M, state)
+    incsteps(state)
+    (state.xn1, false)
+
+end
+
+decide_convergence(P::ZeroProblem) =  decide_convergence(P.M, P.F, P.state, P.options)
+log_step(P::ZeroProblem) = log_step(P.logger, P.M, P.state)
+
+
+"""
+    tracks(P::ZeroProblem)
+
+Show trace of output when `verbose=true` is specified to the problem
+"""
+function tracks(P::ZeroProblem{M,F,S,O,L}) where {M,F,S,O,L<:Tracks}
+    show_trace(P.M, nothing, P.state, P.logger)
+end
+tracks(P::ZeroProblem) = error("Set verbose=true when specifying the problem to see the tracks")
+
+"""
+    find_zero!(P::ZeroProblem)
+
+An alternate interface to `find_zero` whereby a problem is created with `ZeroProblem` and solved
+with `find_zero!`.
+
+Returns `NaN`, not an error, when the problem can not be solved.
+
+Advantages are the `state` object is accessible after solving and may
+help in facilitating hybrid solving techniques. Disadvantage include the
+overhead of creating another object to pass to this function.
+
+```jldoctest find_zero!
+julia> P = Roots.ZeroProblem(Order1(), sin, 3, verbose=true); 
+
+julia> find_zero!(P)
+3.141592653589793
+
+julia> P.state.xstar
+3.141592653589793
+
+julia> Roots.tracks(P)
+Results of univariate zero finding:
+
+* Converged to: 3.141592653589793
+* Algorithm: Roots.Secant()
+* iterations: 4
+* function evaluations: 6
+* stopped as |f(x_n)| ≤ max(δ, max(1,|x|)⋅ϵ) using δ = atol, ϵ = rtol
+
+Trace:
+x_0 =  3.0000000000000000,	 fx_0 =  0.1411200080598672
+x_1 =  3.1425464815525403,	 fx_1 = -0.0009538278181169
+x_2 =  3.1415894805773834,	 fx_2 =  0.0000031730124098
+x_3 =  3.1415926535902727,	 fx_3 = -0.0000000000004795
+x_4 =  3.1415926535897931,	 fx_4 =  0.0000000000000001
+```
+
+"""
+function find_zero!(P::ZeroProblem)
+    log_step(P)            # initial logging
+    for _ in P end         # iterate to complection
+    decide_convergence(P)  # polish answer
 end

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -96,7 +96,20 @@ end
         @test find_zero(M, g1, options, state) ≈ xstar_
     end
 
+    # alternate constructor find_zero!
+    meths = [Order1(), Roots.Order1B(), Roots.King(),
+             Order2(), Roots.Steffensen(), Roots.Order2B(), Roots.Esser(),
+             Order5(), Roots.KumarSinghAkanksha(),
+             Order8(), Roots.Thukral8(),
+             Order16(), Roots.Thukral16()]
+    g1(x) = x^5 - x - 1
+    x0_, xstar_ = 1.16, 1.1673039782614187  # need a good starting point for all to pass
+    for M in meths
+        P = Roots.ZeroProblem(M, g1, x0_)
+        @test find_zero!(P) ≈ xstar_
+    end
 
+    
     ## hybrid
     g1(x) = exp(x) - x^4
     x0_, xstar_ = (5.0, 20.0), 8.613169456441398


### PR DESCRIPTION
Issue 196 was about some interface to get NaN in place of an error.

This goes about it with a slightly different interface, following that of DifferentialEquations.

```
P = Roots.ZeroProblem(Order1(), sin, 3)
find_zero!(P)
```

Don't really like the name `ZeroProblem` for the type, so it isn't exported yet.
