### PR TITLE
fix typing of UnivariateZeroState init

### DIFF
--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -62,8 +62,8 @@ end
 function init_state(method::AbstractSecant, fs, x::Union{Tuple, Vector})
     x0, x1 = promote(float(x[1]), float(x[2]))
     fx0, fx1 = fs(x0), fs(x1)
-    state = UnivariateZeroState(x1, x0, zero(x1)/zero(x1)*oneunit(x1), eltype(x1)[],
-                                fx1, fx0, fx1, eltype(fx1)[],
+    state = UnivariateZeroState(x1, x0, zero(x1)/zero(x1)*oneunit(x1), typeof(x1)[],
+                                fx1, fx0, fx1, typeof(fx1)[],
                                 0, 2,
                                 false, false, false, false, "")
 


### PR DESCRIPTION
`eltype(x1)[]` is incorrectly used here instead of `typeof(x1)[]`. Does not create a problem for most cases since `eltype(x) == typeof(x)` when `x` is a scalar.