### PR TITLE
Common solve

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-nightly
 on:
   pull_request:
     branches:
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0' # lowest supported version
-          - '1'   # last released version
+          - 'nightly'
         os:
           - ubuntu-latest
           - macos-latest
@@ -41,29 +40,3 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: doctest
-            using Roots
-            doctest(Roots)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,11 @@ uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 version = "1.0.8"
 
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
+CommonSolve = "0.1, 0.2"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0"
 julia = "1.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "1.0.8"
+version = "1.0.9"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -5,12 +5,14 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optle
 end
 
 using Printf
+import CommonSolve
+import CommonSolve: init, solve!
 
 export fzero,
        fzeros,
        secant_method
 
-export find_zero, find_zero!, find_zeros,
+export find_zero, find_zero!, find_zeros, init, solve!,
        Order0, Order1, Order2, Order5, Order8, Order16
 
 export Bisection, FalsePosition

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -6,13 +6,14 @@ end
 
 using Printf
 import CommonSolve
-import CommonSolve: init, solve!
+import CommonSolve: solve, solve!, init
 
 export fzero,
        fzeros,
        secant_method
 
-export find_zero, find_zero!, find_zeros, init, solve!,
+export find_zero, find_zero!, find_zeros,
+       ZeroProblem, solve, solve!, init,
        Order0, Order1, Order2, Order5, Order8, Order16
 
 export Bisection, FalsePosition

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -875,7 +875,7 @@ function update_state(M::Brent, f, state::UnivariateZeroState{T,S}, options::Uni
         mflag = false
     end
 
-     d = c
+    d = c
     c,fc = b,fb
 
     if sign(fa) * sign(fs) < 0

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -677,9 +677,10 @@ function find_zero(f, x0; kwargs...)
     find_zero(f, (a, b), Bisection(); kwargs...)
 end
 
+
 # Main method
 # return a zero or NaN.
-## Updates state, could be `find_zero!(state, M, F, options, l)...
+## Updates state, could be `find_zero!(state, M, F, options, l)`...
 """
     find_zero(M, F, state, [options], [l])
 
@@ -917,12 +918,25 @@ function find_zero(M::AbstractUnivariateZeroMethod,
 end
 
 
-
-
-# An alternate interface
-# create a problem, call find_zero!
+## ---------------
+## Create an Iterator interface
 # returns NaN, not an error, if there are issues
-struct ZeroProblem{M,F,S,O,L}
+
+"""
+    ZeroProblem{F,X}
+
+A container for a function and initial guess passed to an iterator to be solved by `find_zero!` or `solve!`.
+"""
+mutable struct ZeroProblem{F,X}
+    F::F
+    x₀::X
+end
+
+
+
+
+## The actual iterating object
+struct ZeroProblemIterator{M,F,S,O,L}
     M::M
     F::F
     state::S
@@ -930,34 +944,27 @@ struct ZeroProblem{M,F,S,O,L}
     logger::L
 end
 
-"""
-    ZeroProblem(M, fs, x0; verbose=false, kwargs...)
+## Initialize a Zero Problem
+function init(𝑭𝑿::ZeroProblem, M::Union{Nothing,AbstractUnivariateZeroMethod}=nothing;
+              verbose=false,
+              kwargs...)
+    F,X = callable_function(𝑭𝑿.F), 𝑭𝑿.x₀
 
-Setup a problem for solution. Call `find_zero!` to solve.
+    if M == nothing
+        x₀,st = iterate(X)
+        M′ = st == nothing ? Order1() : Bisection()
+    else
+            M′ = M
+    end
 
-* `M`: Method. A non-hybrid method (not `Order0`).
-* `fs`: a function or for some methods a tuple of functions
-* `x0`: the initial guess
-* `verbose`: if `true`, then calling `Roots.tracks` on the output will show the steps on the algorithm
-* `kwargs`: passed to `Roots.init_options` to adjust tolerances
-"""
-function ZeroProblem(M::AbstractUnivariateZeroMethod,
-                     fs,
-                     x0;
-                     verbose=false,
-                     kwargs...)
-
-    F = callable_function(fs)
-    state = init_state(M, F, x0)
-    options = init_options(M, state; kwargs...)
+    state = init_state(M′, F, X)
+    options = init_options(M′, state; kwargs...)
     l = verbose ? Tracks(eltype(state.xn1)[], eltype(state.fxn1)[]) : nothing
-
-    ZeroProblem(M,F,state, options, l)
-
+    ZeroProblemIterator(M′,F,state,options,l)
 end
 
 # Iteration interface to handle looping
-function Base.iterate(P::ZeroProblem, state=nothing)
+function Base.iterate(P::ZeroProblemIterator, state=nothing)
 
     M, F, state, options, l = P.M, P.F, P.state, P.options, P.logger
     assess_convergence(M, state, options)  && return  nothing
@@ -969,44 +976,178 @@ function Base.iterate(P::ZeroProblem, state=nothing)
 
 end
 
-decide_convergence(P::ZeroProblem) =  decide_convergence(P.M, P.F, P.state, P.options)
-log_step(P::ZeroProblem) = log_step(P.logger, P.M, P.state)
+decide_convergence(P::ZeroProblemIterator) =  decide_convergence(P.M, P.F, P.state, P.options)
+log_step(P::ZeroProblemIterator) = log_step(P.logger, P.M, P.state)
+
+"Get last element in the iteration, which is xstar, or throw a warning"
+function Base.last(p::ZeroProblemIterator)
+    state = p.state
+    state.convergence_failed && @warn "The problem failed to converge"
+        !(state.x_converged || state.f_converged) && @warn "The problem has not converged. Try calling `solve! first"
+    state.xstar
+end
+
+"Get current state of Zero Problem Iterator `(xᵢ=..., fᵢ=...)`"
+function current(p::ZeroProblemIterator)
+    M, state = p.M, p.state
+    (xᵢ = xs(typeof(M), state), fᵢ = fs(typeof(M), state))
+end
 
 
 """
-    tracks(P::ZeroProblem)
+    tracks(P::ZeroProblemIterator)
 
 Show trace of output when `verbose=true` is specified to the problem
 """
-function tracks(P::ZeroProblem{M,F,S,O,L}) where {M,F,S,O,L<:Tracks}
+function tracks(P::ZeroProblemIterator{M,F,S,O,L}) where {M,F,S,O,L<:Tracks}
     show_trace(P.M, nothing, P.state, P.logger)
 end
-tracks(P::ZeroProblem) = error("Set verbose=true when specifying the problem to see the tracks")
+tracks(P::ZeroProblemIterator) = error("Set verbose=true when specifying the problem to see the tracks")
+
+## show method
+"""
+    xs(M::AbstractUnivariateZeroMethod, state)
+    fs(M::AbstractUnivariateZeroMethod, state)
+
+Return the xs values needed for the next iteration. Return the fs values used for the next iteration.
+"""
+xs(::Type{<:AbstractUnivariateZeroMethod}, state) = state.xn1
+xs(::Type{<:AbstractSecant}, state) = (state.xn0, state.xn1)
+xs(::Type{<:AbstractBracketing}, state) = [state.xn0, state.xn1]
+
+fs(::Type{<:AbstractUnivariateZeroMethod}, state) = state.fxn1
+fs(::Type{<:AbstractSecant}, state) = (state.fxn0, state.fxn1)
+fs(::Type{<:AbstractBracketing}, state) = [state.fxn0, state.fxn1]
+
+function Base.show(io::IO, P::ZeroProblemIterator{M}) where {M<:AbstractUnivariateZeroMethod}
+    state = P.state
+
+    if state.x_converged || state.f_converged
+        print(io, "Converged to x")
+        unicode_subscript(io, state.steps)
+        print(io, ": ", state.xstar)
+    elseif state.stopped
+        print(io, "Failed to converge. Last iterate: ")
+        print(io, current(P))
+    else
+        iszero(state.steps) && print(io,  "$M: ")
+        print(io, "x")
+        unicode_subscript(io, state.steps)
+        print(io, ": ")
+        print(io, xs(M, state))
+    end
+    println(io)
+end
+
+
 
 """
-    find_zero!(P::ZeroProblem)
+   solve(fx::ZeroProblem, [M]; kwargs...)
+   solve!(P::ZeroProblemIterator)
 
-An alternate interface to `find_zero` whereby a problem is created with `ZeroProblem` and solved
-with `find_zero!`.
+Solve for the zero of a function specified through a  `ZeroProblem` or `ZeroProblemIterator`
+
+
+The methods involved with this interface are:
+
+* `ZeroProblem`: used to specificy a problem with a function (or functions) and an initial guess
+* `solve`: to solve for a zero in a `ZeroProblem`
+
+The latter calls the following, which can be useful independently:
+
+* `init`: to initialize an iterator with a method for solution, any adjustments to the default tolerances, and a specification to log the steps or not.
+* `solve!` to iterate to convergence. (Also [`find_zero!`](@ref).)
 
 Returns `NaN`, not an error, when the problem can not be solved.
 
-Advantages are the `state` object is accessible after solving and may
-help in facilitating hybrid solving techniques. Disadvantage include the
-overhead of creating another object to pass to this function.
+## Examples:
+
+```
+fx = ZeroProblem(sin, 3)
+solve(fx)
+```
+
+Or, if the iterator is required
+
+```
+fx = ZeroProblem(sin, 3)
+problem = init(fx)
+solve!(fx)
+```
+
+The default method is `Order1()`, when  `x0` is a number, or `Bisection()` when `x0` is an iterable with 2 or more values.
+
+
+A second position argument for `solve` or `init` is used to specify a different method; keyword arguments can be used to adjust the default tolerances.
+
+
+```
+fx = ZeroProblem(sin,3)
+solve(fx, Order5(), atol=1/100)
+```
+
+The above is equivalent to:
+
+```
+fx = ZeroProblem(sin, 3)
+problem = init(fx, Order5(), atol=1/100)
+solve!(problem)
+```
+
+The argument `verbose=true` for `init` instructs that steps to be logged; these may be viewed with the method `Roots.tracks` for the iterator.
+
+The iterator interface allows for the creation of hybrid solutions, for example, this is essentially how `Order0` is constructed (`Order0` follows secant steps until a bracket is identified, after which is switches to a bracketing algorithm.)
+
+```
+function order0(f, x)
+    fx = ZeroProblem(f, x)
+    p = init(fx, Roots.Secant())
+    xᵢ,st = ϕ = iterate(p)
+    while ϕ != nothing
+        xᵢ, st = ϕ
+        fᵢ₋₁, fᵢ = p.state.fxn0, p.state.fxn1
+        if sign(fᵢ₋₁)*sign(fᵢ) < 0 # check for bracket
+            x0 = (p.state.xn0, p.state.xn1)
+            fx′ = ZeroProblem(f, x0)
+            p = init(fx′, Bisection())
+            solve!(p)
+            break
+        end
+        ϕ = iterate(p, st)
+    end
+    return last(p)
+end
+```
+
+"""
+function solve!(P::ZeroProblemIterator)
+    log_step(P)            # initial logging
+    for _ in P end         # iterate to completion
+    decide_convergence(P)  # polish answer
+end
+
+## -----
+## deprecate this interface at some time.
+
+"""
+    find_zero!(P::ZeroProblemIterator)
+
+An alternate interface to `find_zero` whereby a problem is created with `ZeroProblemIterator` and solved
+with `find_zero!`. The generic [`solve!`](@ref) method is recommened for familiarity.
+
 
 ```jldoctest find_zero
 julia> using Roots
 
-julia> P = Roots.ZeroProblem(Order1(), sin, 3, verbose=true);
+julia> P = ZeroProblem(Order1(), sin, 3, verbose=true);
 
 julia> find_zero!(P)
 3.141592653589793
 
-julia> P.state.xstar
+julia> last(P)
 3.141592653589793
 
-julia> Roots.tracks(P)
+julia> Roots.tracks(P) # possible when `verbose=true` is specified
 Results of univariate zero finding:
 
 * Converged to: 3.141592653589793
@@ -1022,145 +1163,42 @@ x_2 =  3.1415894805773834,	 fx_2 =  0.0000031730124098
 x_3 =  3.1415926535902727,	 fx_3 = -0.0000000000004795
 x_4 =  3.1415926535897931,	 fx_4 =  0.0000000000000001
 ```
-
 """
-function find_zero!(P::ZeroProblem)
-    log_step(P)            # initial logging
-    for _ in P end         # iterate to complection
-    decide_convergence(P)  # polish answer
+function find_zero!(P::ZeroProblemIterator)
+    solve!(P)
 end
 
 
-    ## -- commonsolve interface
-    ## THis has these parts
-    ## show methods for ZeroProblem
-    ## perhaps accessor methods are needed to gather xᵢs and f(xᵢ)s from ZeroProblem would be good
-    ## a new type to bundle together the functions and the x0(s).
-    ## Then init: FX -> ZeroProblem
-    ## solve! iterates over ZeroProblem
-    ## last(p) then store `xstar` (which may be NaN0
+
 """
+    ZeroProblem(M, fs, x0; verbose=false, kwargs...)
 
-## Example:
+Setup an interator interface for the zero problem. Call `find_zero!` or solve! to solve.
 
-```
-fx = FX(sin, 3)
-p = init(fx) # uses Order1()
-solve!(p)
-```
+* `M`: Method. A non-hybrid method (not `Order0`).
+* `fs`: a function or for some methods a tuple of functions
+* `x0`: the initial guess
+* `verbose`: if `true`, then calling `Roots.tracks` on the output will show the steps on the algorithm
+* `kwargs`: passed to `Roots.init_options` to adjust tolerances
 
-```
-fx = FX(sin, (3,4))
-p = init(fx) # uses Bisection()
-solve!(p)
-```
+"""
+function ZeroProblem(M::AbstractUnivariateZeroMethod,
+                     fs,
+                     x0;
+                     verbose=false,
+                     kwargs...)
 
-```
-fx = FX(sin, 3)
-p = init(fx, verbose=true)
-solve!(p)
-Roots.tracks(p) # show info
-```
+    fx = ZeroProblem(fs, x0)
+    problem = init(fx, M; verbose=verbose, kwargs...)
 
-```
-fx = FX(sin,3)
-p = init(Fx, verbose=true)
-for xᵢ ∈ p
-  fxᵢ, fxⱼ = p.state.fxn0, p.state.fxn1
-  if sign(fxᵢ) * sign(fxⱼ) < 0
-    xs = p.state.xn0, p.state.xn1
-    p = init(FX(fx.F, xs), Roots.Bisection())
-    break
-  end
 end
-solve!(p)
 
 
-"""    
-    mutable struct FX{F,X}
-        F::F
-        x₀::X
-    end
-    ## FX0
-    function init(𝑭𝑿::FX, M::Union{Nothing,AbstractUnivariateZeroMethod}=nothing;
-                  verbose=false,
-                  kwargs...)
-        F,X = callable_function(𝑭𝑿.F), 𝑭𝑿.x₀
-        
-        if M == nothing
-            x₀,st = iterate(X)
-            M′ = st == nothing ? Order1() : Bisection()
-        else
-            M′ = M
-        end
-        
-        state = init_state(M′, F, X)
-        options = init_options(M′, state; kwargs...)
-        l = verbose ? Tracks(eltype(state.xn1)[], eltype(state.fxn1)[]) : nothing
-        ZeroProblem(M′,F,state,options,l)
-    end
-    
-    function solve!(ZP::ZeroProblem)
-        find_zero!(ZP)
-    end
-    
-    export FX
 
 
-    # To do
-    # These are methods for working with ZeroProblem
-    # * a show method (needs improvement; should be good replacement for tracks)
-    # * a `last` method to get xstar
-    # * need a method to get [xn0], xn1
-    # * need a method to get [fxn0], fxn1
-    
-    
-    # pun? Get last element in the iteration, which is xstar
-    function Base.last(p::ZeroProblem)
-        state = p.state
-        state.convergence_failed && @warn "The problem failed to converge"
-        !(state.x_converged || state.f_converged) && @warn "The problem has not converged. Try calling `solve! first"
-        state.xstar
-    end
-    function current(p::ZeroProblem)
-        M, state = p.M, p.state
-        (xᵢ = xs(M, state), fᵢ = fs(M, state))
-    end
 
-"""
-    xs(M::AbstractUnivariateZeroMethod, state)
-    fs(M::AbstractUnivariateZeroMethod, state)
 
-Return the xs values needed for the next iteration. Return the fs values used for the next iteration.
-"""  
-    xs(M::AbstractUnivariateZeroMethod, state) = state.xn1
-    xs(M::AbstractSecantMethod, state) = (state.xn0, state.xn1)
-    xs(M::AbstractBracketing, state) = [state.xn0, state.xn1]
-
-    fs(M::AbstractUnivariateZeroMethod, state) = state.fxn1
-    fs(M::AbstractSecantMethod, state) = (state.fxn0, state.fxn1)
-    fs(M::AbstractBracketing, state) = [state.fxn0, state.fxn1]
-
-    ## Show method
-    show_state(io::IO, ::Type{<:AbstractUnivariateZeroMethod}, state) =
-    print(io, @sprintf("%18.16f", float(state.xn1)))
-    show_state(io::IO, ::Type{<:AbstractBracketing}, state) =
-        print(io, @sprintf("[%18.16f, %18.16f]", float(state.xn0), float(state.xn1)))
-
-    show_converged(io::IO, ::Type{<:AbstractUnivariateZeroMethod}, state) =
-        print(io, float(state.xstar))
-
-    function Base.show(io::IO, P::ZeroProblem{M}) where {M<:AbstractUnivariateZeroMethod}
-        state = P.state
-        if state.x_converged || state.f_converged
-            print(io, "Converged to xₙ: ")
-            show_converged(io, M, state)
-        else
-            print(io, iszero(state.steps) ? "$M: xₒ = " : "step $(state.steps): xᵢ = ")
-            show_state(io, M, state)
-        end
-        println(io)            
-    end
+      
 
 
     

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -137,3 +137,12 @@ function identify_starting_point(a, b, sfxs)
     p1 = p0 + (b-a)/(2N) * sfxs[1] * sum(s for s in sfxs[2:end-1])
     p1
 end
+
+## ----
+
+function unicode_subscript(io, j)
+    a = ("⁻","","","₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
+    for i in string(j)
+        print(io, a[Int(i)-44])
+    end
+end

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -87,7 +87,7 @@ end
 @testset "find_zero internals" begin
 
     ##  init_state! method
-    g1(x) = x^5 - x - 1
+    g1 = x -> x^5 - x - 1
     x0_, xstar_ = (1.0, 2.0), 1.1673039782614187
     M = Roots.A42()
     state = Roots.init_state(M, g1, x0_)
@@ -97,21 +97,27 @@ end
         @test find_zero(M, g1, state, options) ≈ xstar_
     end
 
-    # alternate constructor find_zero!
+    # iterator interface (ZeroProblem, solve; init, solve!)
     meths = [Order1(), Roots.Order1B(), Roots.King(),
              Order2(), Roots.Steffensen(), Roots.Order2B(), Roots.Esser(),
              Order5(), Roots.KumarSinghAkanksha(),
              Order8(), Roots.Thukral8(),
              Order16(), Roots.Thukral16()]
     g1(x) = x^5 - x - 1
-    x0_, xstar_ = 1.16, 1.1673039782614187  # need a good starting point for all to pass
+    x0_, xstar_ = 1.16, 1.1673039782614187
+    fx = ZeroProblem(g1, x0_)
     for M in meths
+        @test solve(fx, M) ≈ xstar_
+        P = init(fx, M)
+        solve!(P)
+        @test last(P) ≈ xstar_
+        # these next two methods are to be deprecated:
         P = Roots.ZeroProblem(M, g1, x0_)
         @test find_zero!(P) ≈ xstar_
     end
 
     ## test with early evaluation of bracket
-    f(x) = sin(x)
+    f = x -> sin(x)
     xs = (3.0, 4.0)
     fxs = f.(xs)
     M = Bisection()
@@ -120,7 +126,7 @@ end
 
     
     ## hybrid
-    g1(x) = exp(x) - x^4
+    g1 = x -> exp(x) - x^4
     x0_, xstar_ = (5.0, 20.0), 8.613169456441398
     M = Roots.Bisection()
     state = Roots.init_state(M, g1, x0_)
@@ -142,7 +148,7 @@ end
           Order8(),
           Order16()]
 
-    g1(x) = exp(x) - x^4
+    g1 = x -> exp(x) - x^4
     x0_= (5.0, 20.0)
     M = Ms[1]
     state = Roots.init_state(M, g1, x0_)
@@ -195,7 +201,7 @@ end
         o.fxn0, o.fxn1 = fxn, fwn
     end
 
-    g1(x) = exp(x) - x^4
+    g1 = x -> exp(x) - x^4
     @test find_zero(g1, 8.3, Order3_Test()) ≈ find_zero(g1, 8.3, Order1())
 
 end
@@ -310,7 +316,7 @@ end
     @test fzero(sin, 3, 4, Roots.Brent()) ≈ π
 
     ## issue #188 with A42
-    f(x) = x*(1-x^2)/((x^2+a^2)*(1+a^2*x^2))
+    f = x -> x*(1-x^2)/((x^2+a^2)*(1+a^2*x^2))
     a,r = .18, 0.05
     xs = (r + 1e-12, 1.0)
     @test find_zero(x -> f(r)-f(x), xs, Roots.A42()) ≈ 0.4715797678171889

--- a/test/test_simple.jl
+++ b/test/test_simple.jl
@@ -13,7 +13,7 @@ using Test
     @test isapprox(xrt, pi)
 
     # secant_method
-    fpoly(x) = x^5 - x - 1
+    fpoly = x -> x^5 - x - 1
     xrt = Roots.secant_method(fpoly, 1.0)
     @test abs(fpoly(xrt)) <= 1e-15
 
@@ -22,7 +22,7 @@ using Test
 
 
     # muller
-    fpoly(x) = x^5 - x - 1
+    fpoly = x -> x^5 - x - 1
     xrt = Roots.muller(fpoly, 1.0)
     @test xrt isa Real
     @test abs(fpoly(xrt)) <= 1e-15
@@ -38,7 +38,7 @@ using Test
     @test Roots.muller(expoly, -0.7-0.5im) ≈ -1.0
     
     # dfree
-    fpoly(x) = x^5 - x - 1
+    fpoly = x -> x^5 - x - 1
     xrt = Roots.dfree(fpoly, 1.0)
     @test abs(fpoly(xrt)) <= 1e-14
 


### PR DESCRIPTION
* Use `solve`, `init` and `solve!` from CommonSolve for the iterator interface available with `ZeroProblem`.

* update tests to avoid warnings on function name reuse