### PR TITLE
throw a typed error to allow for better handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -331,7 +331,7 @@ function newton(f, x0; xatol=nothing, xrtol=nothing, maxevals = 100)
         xo = x
     end
 
-    error("No convergence")
+    throw(ConvergenceFailed("No convergence"))
 end
 
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -297,6 +297,8 @@ will be faster for subsequent calls, but may be slower for an initial call.
 Convergence here is decided by x_n ≈ x_{n-1} using the tolerances specified, which both default to
 `eps(T)^4/5` in the appropriate units.
 
+If the convergence fails, will return a `ConvergenceFailed` error.
+
 """
 struct TupleWrapper{F, Fp}
 f::F

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -47,6 +47,8 @@ import Roots.newton, Roots.halley
 
     @test find_zero(x -> (x^2 -2, (x^2-2)/2x), 1.0, Roots.Newton(), Roots.Bisection()) ≈ sqrt(2)
 
+    @test_throws Roots.ConvergenceFailed Roots.newton((x->x^2 + 1, x->2x), 0)
+
 end
 
 @testset "Lith Boonkkamp IJzerman methods" begin


### PR DESCRIPTION
When I switched from `Newton` to the simpler `newton`, my error handling no longer worked as I had anticpated a `Roots.ConvergenceFailed` error in this case (for package ActuaryUtilies.jl). 