### PR TITLE
Remove unnecessary static parameters

### DIFF
--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -171,8 +171,7 @@ end
 
 ## the method converges,
 ## as we bound between x0, nextfloat(x0) is not measured by eps(), but eps(x0)
-function assess_convergence(M::Bisection, state::AbstractUnivariateZeroState{T,S}, options) where {T, S}
-
+function assess_convergence(::Bisection, state::AbstractUnivariateZeroState, options)
     flag, converged = assess_convergence(BisectionExact(), state, options)
     converged && return (flag, converged)
 
@@ -194,8 +193,7 @@ function assess_convergence(M::Bisection, state::AbstractUnivariateZeroState{T,S
 end
 
 # for exact convergence, we can skip some steps
-function assess_convergence(M::BisectionExact, state::UnivariateZeroState{T,S}, options) where {T, S}
-
+function assess_convergence(::BisectionExact, state::UnivariateZeroState, options)
     a,b = state.xn0, state.xn1
     fa, fb = state.fxn0,  state.fxn1
 
@@ -208,8 +206,7 @@ function assess_convergence(M::BisectionExact, state::UnivariateZeroState{T,S}, 
 end
 
 # assumes stopped = :x_converged
-function decide_convergence(M::AbstractBracketing,  F, state::AbstractUnivariateZeroState{T,S}, options, val) where {T,S}
-
+function decide_convergence(::AbstractBracketing,  F, state::AbstractUnivariateZeroState, options, val)
     a,b = state.xn0, state.xn1
     fa, fb = state.fxn0, state.fxn1
 
@@ -262,7 +259,7 @@ function find_zero(fs, x0, method::Bisection;
                    p=nothing,
                    tracks = NullTracks(),
                    verbose=false,
-                   kwargs...) where {M <: Union{Bisection}}
+                   kwargs...)
 
     _options = init_options(Bisection(), Float64, Float64; kwargs...)
     iszero_tol = all(iszero, (_options.xabstol, _options.xreltol, _options.abstol, _options.reltol))
@@ -360,8 +357,7 @@ end
 end
 
 # Cubic if possible, if not, quadratic(3)
-function take_a42_step(a::T, b, d, ee, fa, fb, fd, fe, k, delta=zero(T)) where {T}
-
+function take_a42_step(a, b, d, ee, fa, fb, fd, fe, k, delta=zero(a))
     # if r is NaN or Inf we move on by condition. Faster than checking ahead of time for
     # distinctness
     r = ipzero(a,b,d,ee, fa, fb,fd,fe, delta) # let error and see difference in allcoation?
@@ -369,7 +365,7 @@ function take_a42_step(a::T, b, d, ee, fa, fb, fd, fe, k, delta=zero(T)) where {
     r = newton_quadratic(a,b,d,fa,fb,fd, 3, delta)
 end
 
-function ipzero(a::T, b, c, d, fa, fb, fc, fd, delta=zero(T)) where {T}
+function ipzero(a, b, c, d, fa, fb, fc, fd, delta=zero(a))
     Q11 = (c - d)*fc/(fd - fc)
     Q21 = (b - c)*fb/(fc - fb)
     Q31 = (a - b)*fa/(fb - fa)
@@ -389,7 +385,7 @@ end
 
 # return c in (a+delta, b-delta)
 # adds part of `bracket` from paper with `delta`
-function newton_quadratic(a::T, b, d, fa, fb, fd, k::Int, delta=zero(T)) where {T}
+function newton_quadratic(a, b, d, fa, fb, fd, k::Int, delta=zero(a))
 
     A = f_abd(a,b,d,fa,fb,fd)
     r = isbracket(A,fa) ? b : a
@@ -747,8 +743,8 @@ end
 
 
 
-function update_state(M::Brent, f, state::BrentState{T,S},
-                      options::UnivariateZeroOptions, l = NullTracks()) where {T,S}
+function update_state(::Brent, f, state::BrentState,
+                      options::UnivariateZeroOptions, l = NullTracks())
 
 
     mflag = state.mflag
@@ -756,7 +752,6 @@ function update_state(M::Brent, f, state::BrentState{T,S},
     fa, fb, fc = state.fxn0, state.fxn1, state.fc
 
     # next step depends on points; inverse quadratic
-    s::T = zero(a)
     s = inverse_quadratic_step(a,b,c,fa,fb,fc)
     (isnan(s) || isinf(s)) && (s = secant_step(a,b,fa,fb))
 
@@ -853,16 +848,16 @@ find_zero(x -> x^5 - x - 1, (-2, 2), FalsePosition())
 FalsePosition
 FalsePosition(x=:anderson_bjork) = FalsePosition{x}()
 
-function default_tolerances(::FalsePosition{R}, ::Type{T}, ::Type{S}) where {R, T,S}
+function default_tolerances(::FalsePosition, ::Type{T}, ::Type{S}) where {T,S}
     default_tolerances(Secant(), T, S)
 end
 
 # use fallback for derivative free
-function assess_convergence(method::FalsePosition, state::UnivariateZeroState{T,S}, options) where {T,S}
+function assess_convergence(::FalsePosition, state::UnivariateZeroState, options)
     assess_convergence(Any, state, options)
 end
 
-function decide_convergence(M::FalsePosition,  F, state::AbstractUnivariateZeroState{T,S}, options, val) where {T,S}
+function decide_convergence(::FalsePosition,  F, state::AbstractUnivariateZeroState, options, val)
 
     a,b = state.xn0, state.xn1
     fa, fb = state.fxn0, state.fxn1
@@ -888,8 +883,8 @@ function decide_convergence(M::FalsePosition,  F, state::AbstractUnivariateZeroS
 end
 
 
-function update_state(method::FalsePosition, fs, o::AbstractUnivariateZeroState{T,S},
-                      options::UnivariateZeroOptions, l=NullTracks()) where {T,S}
+function update_state(method::FalsePosition, fs, o::AbstractUnivariateZeroState,
+                      options::UnivariateZeroOptions, l=NullTracks())
 
     a, b =  o.xn0, o.xn1
     fa, fb = o.fxn0, o.fxn1

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -92,8 +92,7 @@ end
 
 
 
-function update_state(method::Order1, F, o::AbstractUnivariateZeroState{T,S}, options, l=NullTracks()) where {T, S}
-
+function update_state(::Order1, F, o::AbstractUnivariateZeroState, options, l=NullTracks())
     xn0, xn1 = o.xn0, o.xn1
     fxn0, fxn1 = o.fxn0, o.fxn1
     Δ = fxn1 * (xn1 - xn0) / (fxn1 - fxn0)
@@ -208,7 +207,7 @@ struct KumarSinghAkanksha <: AbstractSecant end
 
 
 
-function update_state(method::Order5, fs, o::UnivariateZeroState{T,S}, options, l=NullTracks())  where {T, S}
+function update_state(method::Order5, fs, o::UnivariateZeroState, options, l=NullTracks())
     update_state_guarded(method, Secant(), KumarSinghAkanksha(), fs, o, options, l)
 end
 

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -271,38 +271,32 @@ end
 # return f(x); (f(x), f(x)/f'(x)); *or* f(x), (f(x)/f'(x), f'(x)/f''(x), ...) # so N=1, 2 are special cased
 # Callable_Function(output_arity, input_arity, F, p)
 # First handle: x -> (f,f/f', f'/f'', ...)
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{1}, T <: Val{false}, 𝑭, P<:Nothing} =
-    first(F.f(x))
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{1}, T <: Val{false}, 𝑭, P} =
-    first(F.f(x, F.p))
+(F::Callable_Function{Val{1},Val{false},𝑭,Nothing})(x) where {𝑭} = first(F.f(x))
+(F::Callable_Function{Val{1},Val{false},𝑭,P})(x) where {𝑭, P} = first(F.f(x, F.p))
 
-(F::Callable_Function{S,T,𝑭,P})(x) where {N, S <: Val{2}, T <: Val{false}, 𝑭, P<:Nothing} =
-    F.f(x)[1:2]
-(F::Callable_Function{S,T,𝑭,P})(x) where {N, S <: Val{2}, T <: Val{false}, 𝑭, P} =
-    F.f(x, F.p)[1:2]
+(F::Callable_Function{Val{2},Val{false},𝑭,Nothing})(x) where {𝑭} = F.f(x)[1:2]
+(F::Callable_Function{Val{2},Val{false},𝑭,P})(x) where {𝑭, P} = F.f(x, F.p)[1:2]
 
 # N ≥ 3 returns (f, (...))
-(F::Callable_Function{S,T,𝑭,P})(x) where {N, S <: Val{N}, T <: Val{false}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{N},Val{false},𝑭,Nothing})(x) where {N, 𝑭}
     fs = F.f(x)
     fs[1], ntuple(i->fs[i+1], Val(N-1))
 end
-(F::Callable_Function{S,T,𝑭,P})(x) where {N, S <: Val{N}, T <: Val{false}, 𝑭, P} = begin
+function (F::Callable_Function{Val{N},Val{false},𝑭,P})(x) where {N, 𝑭, P}
     fs = F.f(x, F.p)
     fs[1], ntuple(i->fs[i+1], Val(N-1))
 end
 
 ## f is specified as a tuple (f,f',f'', ...)
 ## N =1  return f(x)
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{1}, T <: Val{true}, 𝑭, P<:Nothing} =
-    first(F.f)(x)
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{1}, T <: Val{true}, 𝑭, P} =
-    first(F.f)(x, F.p)
+(F::Callable_Function{Val{1},Val{true},𝑭,Nothing})(x) where {𝑭} = first(F.f)(x)
+(F::Callable_Function{Val{1},Val{true},𝑭,P})(x) where {𝑭, P} = first(F.f)(x, F.p)
 ## N=2 return (f(x), f(x)/f'(x))
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{2}, T <: Val{true}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{2},Val{true},𝑭,Nothing})(x) where {𝑭}
     f, f′ = (F.f[1])(x), (F.f[2])(x)
     f, f/f′
 end
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{2}, T <: Val{true}, 𝑭, P} = begin
+function (F::Callable_Function{Val{2},Val{true},𝑭,P})(x) where {𝑭, P}
     f, f′ = (F.f[1])(x, F.p), (F.f[2])(x, F.p)
     f, f/f′
 end
@@ -310,51 +304,51 @@ end
 ## For N ≥ 3 we return (f, (f/f', f'/f'', ...);
 ## Pay no attention to this code; we hand write a bunch, as the
 ## general formula later runs more slowly.
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{3}, T <: Val{true}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{3},Val{true},𝑭,Nothing})(x) where {𝑭}
     f, f′, f′′ = (F.f[1])(x), (F.f[2])(x), (F.f[3])(x)
     f, (f/f′, f′/f′′)
 end
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{3}, T <: Val{true}, 𝑭, P} = begin
+function (F::Callable_Function{Val{3},Val{true},𝑭,P})(x) where {𝑭, P}
     f, f′, f′′ = (F.f[1])(x, F.p), (F.f[2])(x, F.p), (F.f[3])(x, F.p)
     f, (f/f′, f′/f′′)
 end
 
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{4}, T <: Val{true}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{4},Val{true},𝑭,Nothing})(x) where {𝑭}
     f, f′, f′′, f′′′ = (F.f[1])(x), (F.f[2])(x), (F.f[3])(x), (F.f[4])(x)
     f, (f/f′, f′/f′′, f′′/f′′′)
 end
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{4}, T <: Val{true}, 𝑭, P} = begin
+function (F::Callable_Function{Val{4},Val{true},𝑭,P})(x) where {𝑭, P}
     f, f′,f′′,f′′′ = (F.f[1])(x, F.p), (F.f[2])(x, F.p), (F.f[3])(x, F.p), (F.f[4])(x, F.p)
     𝐓 = eltype(f/f′)
     f, NTuple{3,𝐓}((f/f′, f′/f′′, f′′/f′′′))
 end
 
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{5}, T <: Val{true}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{5},Val{true},𝑭,Nothing})(x) where {𝑭}
     f, f′, f′′, f′′′, f′′′′ = (F.f[1])(x), (F.f[2])(x), (F.f[3])(x), (F.f[4])(x), (F.f[5])(x)
     f, (f/f′, f′/f′′, f′′/f′′′, f′′′/f′′′′)
 end
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{5}, T <: Val{true}, 𝑭, P} = begin
+function (F::Callable_Function{Val{5},Val{true},𝑭,P})(x) where {𝑭, P}
     f, f′,f′′,f′′′,f′′′′ = (F.f[1])(x, F.p), (F.f[2])(x, F.p), (F.f[3])(x, F.p), (F.f[4])(x, F.p), (F.f[5])(x, F.p)
     f, (f/f′, f′/f′′, f′′/f′′′, f′′′/f′′′′)
 end
 
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{6}, T <: Val{true}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{6},Val{true},𝑭,Nothing})(x) where {𝑭}
     f, f′, f′′, f′′′, f′′′′, f′′′′′ = (F.f[1])(x), (F.f[2])(x), (F.f[3])(x), (F.f[4])(x), (F.f[5])(x),(F.f[6])(x)
     f, (f/f′, f′/f′′, f′′/f′′′, f′′′/f′′′′, f′′′′/f′′′′′)
 end
-(F::Callable_Function{S,T,𝑭,P})(x) where {S <: Val{6}, T <: Val{true}, 𝑭, P} = begin
+function (F::Callable_Function{Val{6},Val{true},𝑭,P})(x) where {𝑭, P}
     f, f′,f′′,f′′′,f′′′′, f′′′′′ = (F.f[1])(x, F.p), (F.f[2])(x, F.p), (F.f[3])(x, F.p), (F.f[4])(x, F.p), (F.f[5])(x, F.p), (F.f[6])(x, F.p)
     f, (f/f′, f′/f′′, f′′/f′′′, f′′′/f′′′′, f′′′′/f′′′′′)
 end
 
 # faster with the above written out, should generate them...
-(F::Callable_Function{S,T,𝑭,P})(x) where {𝐍, S <: Val{𝐍}, T <: Val{true}, 𝑭, P<:Nothing} = begin
+function (F::Callable_Function{Val{𝐍},Val{true},𝑭,Nothing})(x) where {𝐍, 𝑭}
     fs = ntuple(i -> F.f[i](x), Val(𝐍))
     first(fs), ntuple(i -> fs[i]/fs[i+1], Val(𝐍-1))
 end
 
-(F::Callable_Function{S,T,𝑭,P})(x) where {𝐍, S <: Val{𝐍}, T <: Val{true}, 𝑭, P} = begin
-    fs = ntuple(i -> F.f[i](x, p), Val(𝐍))
+function (F::Callable_Function{Val{𝐍},Val{true},𝑭,P})(x) where {𝐍, 𝑭, P}
+    fs = ntuple(i -> F.f[i](x, F.p), Val(𝐍))
     first(fs), ntuple(i -> fs[i]/fs[i+1], Val(𝐍-1))
 end
 
@@ -397,8 +391,7 @@ In `decide_convergence`, stopped values (and `:x_converged` when `strict=false`)
 
 
 """
-function assess_convergence(method::Any, state::AbstractUnivariateZeroState{T,S}, options) where {T,S}
-
+function assess_convergence(::Any, state::AbstractUnivariateZeroState, options)
     # return convergence_flag, boolean
 
     xn0, xn1 = state.xn0, state.xn1
@@ -433,7 +426,7 @@ end
 
 When the algorithm terminates, this function decides the stopped value or returns NaN
 """
-function decide_convergence(M::AbstractUnivariateZeroMethod,  F, state::AbstractUnivariateZeroState{T,S}, options, val) where {T,S}
+function decide_convergence(::AbstractUnivariateZeroMethod, F, state::AbstractUnivariateZeroState, options, val)
 
     xn0, xn1 = state.xn0, state.xn1
     fxn1 = state.fxn1
@@ -685,7 +678,7 @@ end
 # defaults when method is not specified
 # if a number, use Order0
 # O/w use a bracketing method of an assumed iterable
-find_zero(f, x0::T; kwargs...)  where {T <: Number} = find_zero(f, x0, Order0(); kwargs...)
+find_zero(f, x0::Number; kwargs...) = find_zero(f, x0, Order0(); kwargs...)
 find_zero(f, x0; kwargs...) = find_zero(f, x0, Bisection(); kwargs...)
 
 

--- a/src/non_simple.jl
+++ b/src/non_simple.jl
@@ -33,19 +33,19 @@ struct KingState{T,S} <: AbstractUnivariateZeroState{T,S}
 end
 
 
-function init_state(M::Union{King, Order1B}, F, x₀, x₁::T, fx₀, fx₁::S) where {T,S}
-    fₛ₀ = F(x₀ - fx₀*oneunit(T)/oneunit(S))
+function init_state(::Union{King, Order1B}, F, x₀, x₁, fx₀, fx₁)
+    fₛ₀ = F(x₀ - fx₀ * oneunit(x₀) / oneunit(fx₀))
     G₀ = -fx₀^2 / (fₛ₀ - fx₀)
     KingState(x₁, x₀, fx₁, fx₀, G₀)
 end
 initial_fncalls(::Union{King, Order1B}) = 3
 
-function update_state(method::Order1B, F, o::KingState{T,S}, options, l=NullTracks())  where {T, S}
+function update_state(::Order1B, F, o::KingState, options, l=NullTracks())
     if do_guarded_step(Order1B(), o)
         state, flag = update_state(Order1(), F, o, options, l)
 
         x0,fx0 = state.xn0, state.fxn0 # clunky! Need to update G₀ after Order1() step
-        fₛ = F(x0 - fx0*oneunit(T)/oneunit(S))
+        fₛ = F(x0 - fx0*oneunit(x0)/oneunit(fx0))
         incfn(l)
         G₀ = -fx0^2 / (fₛ - fx0)
         @set! state.G0 = G₀
@@ -57,14 +57,14 @@ function update_state(method::Order1B, F, o::KingState{T,S}, options, l=NullTrac
 end
 
 
-function update_state(method::King, F,
-                      o::KingState{T,S}, options, l=NullTracks())  where {T, S}
+function update_state(::King, F,
+                      o::KingState, options, l=NullTracks())
 
 
     x0, x1 = o.xn0, o.xn1
     fx0, fx1 = o.fxn0, o.fxn1
     G₀ = o.G0
-    fₛ₁ = F(x1 - fx1*oneunit(T)/oneunit(S))
+    fₛ₁ = F(x1 - fx1*oneunit(x1)/oneunit(fx1))
     incfn(l)
     G₁ = -fx1^2 / (fₛ₁ - fx1)
 
@@ -131,8 +131,8 @@ find_zero(g, x0, Roots.Order2B(), verbose=true) #  4 / 10
 struct Esser <: AbstractSecant end
 struct Order2B <: AbstractSecant end
 
-function update_state(method::Order2B, fs, o::AbstractUnivariateZeroState{T,S}, options, l=NullTracks())  where {T, S}
-     update_state_guarded(method, Secant(), Esser(), fs, o, options, l)
+function update_state(method::Order2B, fs, o::AbstractUnivariateZeroState, options, l=NullTracks())
+    update_state_guarded(method, Secant(), Esser(), fs, o, options, l)
 end
 
 function update_state(method::Esser, F,

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-SpecialFunctions 0.1.1
-JSON


### PR DESCRIPTION
Removes some static parameters that are not needed (https://docs.julialang.org/en/v1/manual/style-guide/#Don't-use-unnecessary-static-parameters).