### PR TITLE
Base.broadcastable for ZeroProblem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "1.3.11"
+version = "1.3.12"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -10,7 +10,6 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 [compat]
 CommonSolve = "0.1, 0.2"
 Setfield = "0.7, 0.8"
-SpecialFunctions = "0.8, 0.9, 0.10, 1"
 julia = "1.0"
 
 [extras]

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -760,6 +760,7 @@ struct ZeroProblem{F,X}
     F::F
     x₀::X
 end
+Base.broadcastable(p::ZeroProblem) = Ref(p)
 
 ## The actual iterating object
 struct ZeroProblemIterator{M,N,F,S,O,L}

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -295,6 +295,11 @@ end
         @test solve(Za, M, p=2) ≈ α₂
         @test solve!(init(Za, M, 2)) ≈ α₂
     end
+
+    ## test broadcasting semantics with ZeroProblem
+    Z = ZeroProblem((x,p) -> cos(x) - p, pi/4)
+    @test all(solve.(Z, (1,2)) .≈ (solve(Z, 1), solve(Z,2)))
+
 end
 
 @testset "find_zero issue tests" begin


### PR DESCRIPTION
Make `Base.Broadcastable(::ZeroProblem)` be a reference to avoid broadcasting over non-iterable ZeroProblem instances