### PR TITLE
add ITP bracketing method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "1.3.14"
+version = "1.3.15"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -130,6 +130,7 @@ Bisection
 Roots.A42
 Roots.AlefeldPotraShi
 Roots.Brent
+Roots.ITP
 FalsePosition
 Roots.LithBoonkkampIJzermanBracket
 ```

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -879,7 +879,6 @@ struct ITPState{T,S,R} <: AbstractUnivariateZeroState{T,S}
     d::T
 end
 
-
 function init_state(M::ITP, F, x₀, x₁, fx₀, fx₁)
 
     if x₀ > x₁
@@ -910,13 +909,13 @@ function update_state(M::ITP, F, o, options, l=NullTracks())
     if iszero(ϵ2n₁₂)
         # we need the options to set the ϵ⋅2^n₁₂ part of r.
         ϵ = max(options.xabstol, max(abs(a), abs(b)) * options.xreltol)
-        ϵ2n₁₂ = ϵ * 2.0 ^ (ceil(Int, log2((b-a)/(2ϵ))) + M.n₀)
+        ϵ2n₁₂ = ϵ * exp2(ceil(Int, log2((b-a)/(2ϵ))) + M.n₀)
         @set! o.ϵ2n₁₂ = ϵ2n₁₂
     end
 
     Δ = b-a
     x₁₂ = a + Δ/2  # middle must be (a+b)/2
-    r = ϵ2n₁₂ / (2.0)^j - Δ/2
+    r = ϵ2n₁₂ / exp2(j) - Δ/2
     δ = κ₁ * Δ^κ₂ # a numeric literal for  κ₂ is faster
     # δ = κ₁ * Δ^2
     xᵣ = (b*fa - a*fb) / (fa - fb)

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -916,15 +916,21 @@ function update_state(M::ITP, F, o, options, l=NullTracks())
 
     Δ = b-a
     x₁₂ = a + Δ/2  # middle must be (a+b)/2
-    r = ϵ2n₁₂ / 2^j - Δ/2
+    r = ϵ2n₁₂ / (2.0)^j - Δ/2
     δ = κ₁ * Δ^κ₂ # a numeric literal for  κ₂ is faster
-    #    δ = κ₁ * Δ^2
+    # δ = κ₁ * Δ^2
     xᵣ = (b*fa - a*fb) / (fa - fb)
 
     σ = sign(x₁₂ - xᵣ)
     xₜ = δ ≤ abs(x₁₂ - xᵣ) ? xᵣ + σ*δ : x₁₂
 
     c = xᵢₜₚ = abs(xₜ - x₁₂) ≤ r ? xₜ : x₁₂ - σ * r
+
+    if !(a < c < b)
+        nextfloat(a) ≥ b && log_message(l, "Algorithm stopped narrowing bracketing interval")
+        return (o, true)
+    end
+
     fc = F(c)
     incfn(l)
 

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -829,7 +829,7 @@ end
 ## --------------------------------------------------
 
 """
-    Roots.ITP(;[κ₁, κ₂, n₀])
+    Roots.ITP(;[κ₁-0.2, κ₂=2, n₀=1])
 
 Use the [ITP](https://en.wikipedia.org/wiki/ITP_method) bracketing
 method.  This method claims it "is the first root-finding algorithm
@@ -842,7 +842,7 @@ The values `κ1`, `κ₂`, and `n₀` are tuning parameters.
 The
 [suggested](https://docs.rs/kurbo/0.8.1/kurbo/common/fn.solve_itp.html)
 value of `κ₁` is `0.2/(b-a)`, but the default here is `0.2`. The value
-of `κ₂` is hardcoded to be `2`, and the default value of `n₀=1`.
+of `κ₂` is `2`, and the default value of `n₀` is `1`.
 
 ## Note:
 
@@ -858,11 +858,11 @@ struct ITP{T,S} <: AbstractAlefeldPotraShi
     n₀::Int
     function ITP(κ₁::T′, κ₂::S, n₀::Int) where {T′, S}
         0 ≤ κ₁ < Inf             ||   throw(ArgumentError("κ₁ must be between 0 and ∞"))
-        1 ≤ κ₂ < (3+sqrt(5))/2  ||   throw(ArgumentError("κ₂ must be between 1 and 1 plus the golden ratio"))
+        1 ≤ κ₂ < (3+√5)/2        ||   throw(ArgumentError("κ₂ must be between 1 and 1 plus the golden ratio"))
         0 < n₀ < Inf             ||   throw(ArgumentError("n₀ must be between 0 and ∞"))
         T = float(T′)
 
-        κ₂ == 2 || throw(ArgumentError("κ₂ is hardcoded to be 2"))
+        ## κ₂ == 2 || throw(ArgumentError("κ₂ is hardcoded to be 2"))
 
         new{T,S}(float(κ₁), κ₂, n₀)
     end
@@ -880,7 +880,6 @@ struct ITPState{T,S,R} <: AbstractUnivariateZeroState{T,S}
 end
 
 
-## if __middle is used, then this should pass in m, f(m)
 function init_state(M::ITP, F, x₀, x₁, fx₀, fx₁)
 
     if x₀ > x₁
@@ -916,10 +915,10 @@ function update_state(M::ITP, F, o, options, l=NullTracks())
     end
 
     Δ = b-a
-    x₁₂ = a + Δ/2  # can't use _middle here
+    x₁₂ = a + Δ/2  # middle must be (a+b)/2
     r = ϵ2n₁₂ / 2^j - Δ/2
-#    δ = κ₁ * Δ^κ₂ # a numeric literal for  κ₂ is faster
-    δ = κ₁ * Δ^2
+    δ = κ₁ * Δ^κ₂ # a numeric literal for  κ₂ is faster
+    #    δ = κ₁ * Δ^2
     xᵣ = (b*fa - a*fb) / (fa - fb)
 
     σ = sign(x₁₂ - xᵣ)

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -915,7 +915,7 @@ function update_state(M::ITP, F, o, options, l=NullTracks())
 
     Δ = b-a
     x₁₂ = a + Δ/2  # middle must be (a+b)/2
-    r = ϵ2n₁₂ / exp2(j) - Δ/2
+    r = ϵ2n₁₂ * exp2(-j) - Δ/2
     δ = κ₁ * Δ^κ₂ # a numeric literal for  κ₂ is faster
     # δ = κ₁ * Δ^2
     xᵣ = (b*fa - a*fb) / (fa - fb)

--- a/src/bracketing.jl
+++ b/src/bracketing.jl
@@ -908,7 +908,7 @@ function update_state(M::ITP, F, o, options, l=NullTracks())
 
     x₁₂ = (a+b)/2 # __middle(a,b)
     r = ϵ2n₁₂ / 2^j - (b-a)/2
-    δ = κ₁ * (b - a)^κ₂
+    δ = κ₁ * (b - a)^2  # ^κ₂ a numeric literal for  κ₂ is faster
 
     xᵣ = (b*fa - a*fb) / (fa - fb)
 

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -16,6 +16,7 @@ import BenchmarkTools
         Roots.A42(),
         Roots.AlefeldPotraShi(),
         Roots.Brent(),
+        Roots.ITP(),
         Roots.Newton(),
         Roots.Halley(),
         Roots.Schroder(),

--- a/test/test_bracketing.jl
+++ b/test/test_bracketing.jl
@@ -228,6 +228,10 @@ avg(x) = sum(x) / length(x)
     @test maxresidual <= 5e-15
     @test avg(cnts) <= 4700
 
+    result = run_tests((f, b) -> find_zero(f, b, Roots.ITP()), name="ITP")
+    @test length(result.failures) == 0
+    @test result.maxresidual <= sqrt(eps()) #
+
     ## brent has some failures
     Ms = [Roots.Brent()]
     results = [run_tests((f, b) -> find_zero(f, b, M), name="$M") for M in Ms]


### PR DESCRIPTION
cf [discourse](https://discourse.julialang.org/t/julia-implementation-of-the-interpolate-truncate-project-itp-root-finding-algorithm/77739)

To match Wikipedia's example:

```
julia> solve(ZeroProblem(x -> x^3 - x - 2, (1,2)), 
       Roots.ITP(κ₁=0.1, κ₂=2, n₀=1), 
       xatol=1e-5, xrtol=0.0, 
       verbose=true)
Results of univariate zero finding:

* Converged to: 1.5213830127326777
* Algorithm: Roots.ITP{Float64, Int64}(0.1, 2, 1)
* iterations: 6
* function evaluations ≈ 7
* stopped as x_n ≈ x_{n-1} using atol=xatol, rtol=xrtol

Trace:
(a_0, b_0) = ( 0.0000000000000000,  2.0000000000000000)
(a_1, b_1) = ( 1.0000000000000000,  2.0000000000000000)
(a_2, b_2) = ( 1.4333333333333333,  2.0000000000000000)
(a_3, b_3) = ( 1.4333333333333333,  1.5271314505696607)
(a_4, b_4) = ( 1.5200928115097818,  1.5271314505696607)
(a_5, b_5) = ( 1.5213789911605158,  1.5271314505696607)
(a_6, b_6) = ( 1.5213789911605158,  1.5213830127326777)


1.5213789911605158
```