### PR TITLE
Increment version, make ref to `Tracker`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "1.3.15"
+version = "1.4.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -591,7 +591,7 @@ tuple of functions is used. For the classical algorithms, a function returning `
 * `rtol`  - relative tolerance for `f(x)` values.
 * `maxevals`   - limit on maximum number of iterations.
 * `strict` - if `false` (the default), when the algorithm stops, possible zeros are checked with a relaxed tolerance.
-* `verbose` - if `true` a trace of the algorithm will be shown on successful completion. See the internal `Tracks` object to save this trace.
+* `verbose` - if `true` a trace of the algorithm will be shown on successful completion. See the internal [`Tracks`](@ref) object to save this trace.
 
 See the help string for `Roots.assess_convergence` for details on
 convergence. See the help page for `Roots.default_tolerances(method)`


### PR DESCRIPTION
This PR serves to increment the version number, effectively giving me contributor credit for making documentation improvements to `Tracker`. It also makes a reference to `Tracker` in the docstring for `find_zero`, as there now is a section for tracking in the documentation.