### PR TITLE
Cleanup find zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build
 docs/site
 test/benchmarks.json
 Manifest.toml
+TODO.md

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -401,10 +401,10 @@ julia> g(x, p=1) = cos(x) - x/p;
 julia> Z = ZeroProblem(g, (0.0, pi/2))
 ZeroProblem{typeof(g), Tuple{Float64, Float64}}(g, (0.0, 1.5707963267948966))
 
-julia> solve(Z, Secant(), 2) # uses p=2
+julia> solve(Z, Secant(); p=2) # uses p=2
 1.0298665293222589
 
-julia> solve(Z, Bisection(), 3, xatol=1/16) # p=3; uses keywords for tolerances
+julia> solve(Z, Bisection(); p=3, xatol=1/16) # p=3; uses keywords for tolerances
 1.1959535058744393
 ```
 

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -66,7 +66,7 @@ end
 ## Alefeld, Potra, Shi have two algorithms belosw, one is most efficient, but
 ## slightly slower than other.
 
-abstract type AbstractAlefeldPotraShi <: AbstractBracketing end
+abstract type AbstractAlefeldPotraShi <: AbstractBracketingMethod end
 initial_fncalls(::AbstractAlefeldPotraShi) = 3 # worst case assuming fx₀, fx₁,fc must be computed
 
 ## ----
@@ -356,4 +356,3 @@ function update_state(M::A42, F, state::A42State{T,S}, options, l=NullTracks()) 
 
     return state, false
 end
-

--- a/src/Bracketing/bisection.jl
+++ b/src/Bracketing/bisection.jl
@@ -21,13 +21,13 @@ min(abs(a), abs(b)) * rtol)`. The latter is used only if the default
 tolerances are adjusted.
 
 """
-struct Bisection <: AbstractBisection end
+struct Bisection <: AbstractBisectionMethod end
 
-initial_fncalls(::AbstractBisection) = 3 # middle
+initial_fncalls(::AbstractBisectionMethod) = 3 # middle
 
 # Bisection using __middle should have a,b on same side of 0.0 (though
 # possibly, may be -0.0, 1.0 so not guaranteed to be of same sign)
-function init_state(::AbstractBisection, F, x₀, x₁, fx₀, fx₁; m=_middle(x₀, x₁), fm=F(m))
+function init_state(::AbstractBisectionMethod, F, x₀, x₁, fx₀, fx₁; m=_middle(x₀, x₁), fm=F(m))
 
     if x₀ > x₁
         x₀, x₁, fx₀, fx₁ = x₁, x₀, fx₁, fx₀
@@ -53,7 +53,7 @@ const FloatNN = Union{Float64,Float32,Float16}
 
 # for Bisection, the defaults are zero tolerances and strict=true
 """
-    default_tolerances(M::AbstractBisection, [T], [S])
+    default_tolerances(M::AbstractBisectionMethod, [T], [S])
 
 For `Bisection` when the `x` values are of type `Float64`, `Float32`,
 or `Float16`, the default tolerances are zero and there is no limit on
@@ -65,7 +65,7 @@ point values.
 For other types, default non-zero tolerances for `xatol` and `xrtol` are given.
 
 """
-function default_tolerances(::AbstractBisection, ::Type{T}, ::Type{S′}) where {T<:FloatNN,S′}
+function default_tolerances(::AbstractBisectionMethod, ::Type{T}, ::Type{S′}) where {T<:FloatNN,S′}
     S = real(float(S′))
     xatol = 0 * oneunit(S)
     xrtol = 0 * one(T)
@@ -78,7 +78,7 @@ function default_tolerances(::AbstractBisection, ::Type{T}, ::Type{S′}) where 
 end
 
 # not float uses some non-zero tolerances for `x`
-function default_tolerances(::AbstractBisection, ::Type{T′}, ::Type{S′}) where {T′,S′}
+function default_tolerances(::AbstractBisectionMethod, ::Type{T′}, ::Type{S′}) where {T′,S′}
     T,S = real(float(T′)), real(float(S′))
     xatol = eps(T)^3 * oneunit(T)
     xrtol = eps(T) * one(T) # unitless
@@ -157,7 +157,7 @@ end
 
 ## --------------------------------------------------
 
-function update_state(M::AbstractBisection, F, o, options, l=NullTracks())
+function update_state(M::AbstractBisectionMethod, F, o, options, l=NullTracks())
     a, b = o.xn0, o.xn1
     fa, fb = o.fxn0, o.fxn1
 

--- a/src/Bracketing/bisection.jl
+++ b/src/Bracketing/bisection.jl
@@ -72,9 +72,8 @@ function default_tolerances(::AbstractBisectionMethod, ::Type{T}, ::Type{S′}) 
     atol = 0 * oneunit(S)
     rtol = 0 * one(S)
     maxevals = typemax(Int)
-    maxfnevals = typemax(Int)
     strict = true
-    (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
+    (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
 # not float uses some non-zero tolerances for `x`
@@ -85,9 +84,8 @@ function default_tolerances(::AbstractBisectionMethod, ::Type{T′}, ::Type{S′
     atol = 0 * oneunit(S)
     rtol = 0 * one(S)
     maxevals = typemax(Int)
-    maxfnevals = typemax(Int)
     strict = true
-    (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
+    (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
 

--- a/src/Bracketing/bracketing.jl
+++ b/src/Bracketing/bracketing.jl
@@ -35,9 +35,8 @@ function default_tolerances(::AbstractBracketingMethod, ::Type{T}, ::Type{S}) wh
     atol = 0 * oneunit(real(S))
     rtol = 0 * one(real(S))
     maxevals = 60
-    maxfnevals = typemax(Int)
     strict = true
-    (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
+    (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
 

--- a/src/Bracketing/bracketing.jl
+++ b/src/Bracketing/bracketing.jl
@@ -1,27 +1,27 @@
 ### Bracketing method defaults
 
-function init_state(M::AbstractBracketing, F::Callable_Function, x)
+function init_state(M::AbstractBracketingMethod, F::Callable_Function, x)
     x₀, x₁ = adjust_bracket(x)
     fx₀, fx₁ = F(x₀), F(x₁)
     state = init_state(M, F, x₀, x₁, fx₀, fx₁)
 end
 
-function init_state(M::AbstractBracketing, F, x₀, x₁, fx₀, fx₁)
+function init_state(M::AbstractBracketingMethod, F, x₀, x₁, fx₀, fx₁)
     (iszero(fx₀) || iszero(fx₁)) && return UnivariateZeroState(x₁, x₀, fx₁, fx₀)
     assert_bracket(fx₀, fx₁)
     a, b, fa, fb = (x₀ < x₁) ? (x₀, x₁, fx₀, fx₁) : (x₁, x₀, fx₁, fx₀)
     UnivariateZeroState(b, a, fb, fa)
 end
 
-Base.last(state::AbstractUnivariateZeroState, M::AbstractBracketing) =
+Base.last(state::AbstractUnivariateZeroState, M::AbstractBracketingMethod) =
     state.xn0 < state.xn1 ? (state.xn0, state.xn1) : (state.xn1, state.xn0)
 
-fn_argout(::AbstractBracketing) = 1
-initial_fncalls(::AbstractBracketing) = 2
+fn_argout(::AbstractBracketingMethod) = 1
+initial_fncalls(::AbstractBracketingMethod) = 2
 
 ## tracks for bisection, different from secant, we show bracketing interval
 ## No init here; for Bisection() [a₀, b₀] is just lost.
-function log_step(l::Tracks, M::AbstractBracketing, state; init::Bool=false)
+function log_step(l::Tracks, M::AbstractBracketingMethod, state; init::Bool=false)
     a, b = state.xn0, state.xn1
     push!(l.abₛ, a < b ? (a,b) : (b,a))
     !init && log_iteration(l, 1)
@@ -29,7 +29,7 @@ function log_step(l::Tracks, M::AbstractBracketing, state; init::Bool=false)
 end
 
 # use xatol, xrtol only, but give some breathing room over the strict ones and cap number of steps
-function default_tolerances(::AbstractBracketing, ::Type{T}, ::Type{S}) where {T,S}
+function default_tolerances(::AbstractBracketingMethod, ::Type{T}, ::Type{S}) where {T,S}
     xatol = eps(real(T))^3 * oneunit(real(T))
     xrtol = eps(real(T))  # unitless
     atol = 0 * oneunit(real(S))
@@ -43,7 +43,7 @@ end
 
 
 function assess_convergence(
-    method::AbstractBracketing,
+    M::AbstractBracketingMethod,
     state::AbstractUnivariateZeroState,
     options,
 )
@@ -76,7 +76,7 @@ end
 
 # assumes stopped = :x_converged
 function decide_convergence(
-    ::AbstractBracketing,
+    ::AbstractBracketingMethod,
     F,
     state::AbstractUnivariateZeroState,
     options,

--- a/src/Bracketing/bracketing.jl
+++ b/src/Bracketing/bracketing.jl
@@ -13,6 +13,9 @@ function init_state(M::AbstractBracketing, F, x₀, x₁, fx₀, fx₁)
     UnivariateZeroState(b, a, fb, fa)
 end
 
+Base.last(state::AbstractUnivariateZeroState, M::AbstractBracketing) =
+    state.xn0 < state.xn1 ? (state.xn0, state.xn1) : (state.xn1, state.xn0)
+
 fn_argout(::AbstractBracketing) = 1
 initial_fncalls(::AbstractBracketing) = 2
 

--- a/src/Bracketing/brent.jl
+++ b/src/Bracketing/brent.jl
@@ -7,7 +7,7 @@ This method uses a choice of inverse quadratic interpolation or a secant
 step, falling back on bisection if necessary.
 
 """
-struct Brent <: AbstractBracketing end
+struct Brent <: AbstractBracketingMethod end
 
 struct BrentState{T,S} <: AbstractUnivariateZeroState{T,S}
     xn1::T

--- a/src/Bracketing/chandrapatlu.jl
+++ b/src/Bracketing/chandrapatlu.jl
@@ -10,7 +10,7 @@ Chandrapatla's algorithm chooses between an inverse quadratic step or a bisectio
 
 
 """
-struct Chandrapatla <: AbstractBracketing end
+struct Chandrapatla <: AbstractBracketingMethod end
 
 struct ChandrapatlaState{T,S} <: AbstractUnivariateZeroState{T,S}
     xn1::T

--- a/src/Bracketing/false_position.jl
+++ b/src/Bracketing/false_position.jl
@@ -41,9 +41,8 @@ function default_tolerances(::FalsePosition{12}, ::Type{T}, ::Type{S}) where {T,
     atol = 4 * eps(real(float(S))) * oneunit(real(S))
     rtol = 4 * eps(real(float(S))) * one(real(S))
     maxevals = 250
-    maxfnevals = typemax(Int)
     strict = false
-    (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
+    (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
 

--- a/src/Bracketing/false_position.jl
+++ b/src/Bracketing/false_position.jl
@@ -1,4 +1,4 @@
-struct FalsePosition{R} <: AbstractSecant end
+struct FalsePosition{R} <: AbstractSecantMethod end
 
 """
 

--- a/src/Bracketing/itp.jl
+++ b/src/Bracketing/itp.jl
@@ -22,7 +22,7 @@ by `@TheLateKronos`, who supplied the original version of the code
 below.
 
 """
-struct ITP{T,S} <: AbstractBracketing
+struct ITP{T,S} <: AbstractBracketingMethod
     κ₁::T
     κ₂::S
     n₀::Int

--- a/src/Bracketing/ridders.jl
+++ b/src/Bracketing/ridders.jl
@@ -23,7 +23,7 @@ true
 `f=F', g=F''/2, h=F'''/6`, suggesting converence at rate `≈ 1.839...`. It uses two function evaluations per step, so
  its order of convergence is `≈ 1.225...`.
 """
-struct Ridders <: AbstractBracketing end
+struct Ridders <: AbstractBracketingMethod end
 
 function update_state(M::Ridders, F, o, options, l=NullTracks())
 

--- a/src/Derivative/halley_like.jl
+++ b/src/Derivative/halley_like.jl
@@ -26,12 +26,12 @@ initial_fncalls(M::AbstractHalleyLikeMethod) = 2 * 3
 fn_argout(::AbstractHalleyLikeMethod) = 3
 
 
-function update_state(method::AbstractΔMethod, F, o::HalleyState{T,S}, options, l=NullTracks()) where {T,S}
+function update_state(M::AbstractΔMethod, F, o::HalleyState{T,S}, options, l=NullTracks()) where {T,S}
     xn = o.xn1
     fxn = o.fxn1
     r1::T, r2::T = o.Δ, o.ΔΔ
 
-    Δ::T = calculateΔ(method, r1, r2)
+    Δ::T = calculateΔ(M, r1, r2)
     if isissue(Δ)
         log_message(l, "Issue with computing `Δ`")
         return (o, true)
@@ -180,8 +180,8 @@ const Schroeder = Schroder # either spelling
 const Schröder = Schroder
 
 ## r1, r2 are o.Δ, o.ΔΔ
-calculateΔ(method::Halley, r1, r2) = 2r2 / (2r2 - r1) * r1
-calculateΔ(method::QuadraticInverse, r1, r2) = (1 + r1 / (2r2)) * r1
-calculateΔ(method::ChebyshevLike, r1, r2) = (1 + r1 / (2r2) * (1 + r1 / r2)) * r1
-calculateΔ(method::SuperHalley, r1, r2) = (1 + r1 / (2r2 - 2r1)) * r1
-calculateΔ(method::Schroder, r1, r2) = r2 / (r2 - r1) * r1
+calculateΔ(::Halley, r1, r2) = 2r2 / (2r2 - r1) * r1
+calculateΔ(::QuadraticInverse, r1, r2) = (1 + r1 / (2r2)) * r1
+calculateΔ(::ChebyshevLike, r1, r2) = (1 + r1 / (2r2) * (1 + r1 / r2)) * r1
+calculateΔ(::SuperHalley, r1, r2) = (1 + r1 / (2r2 - 2r1)) * r1
+calculateΔ(::Schroder, r1, r2) = r2 / (r2 - r1) * r1

--- a/src/Derivative/lith.jl
+++ b/src/Derivative/lith.jl
@@ -308,7 +308,7 @@ the next step.
 
 
 """
-struct LithBoonkkampIJzermanBracket <: AbstractBracketing end
+struct LithBoonkkampIJzermanBracket <: AbstractBracketingMethod end
 struct LithBoonkkampIJzermanBracketState{T,S,R} <: AbstractUnivariateZeroState{T,S}
     xn1::T
     xn0::T

--- a/src/Derivative/lith.jl
+++ b/src/Derivative/lith.jl
@@ -457,9 +457,8 @@ function default_tolerances(
     atol = zero(float(one(S))) * oneunit(S)
     rtol = 2eps(float(one(S))) * one(S)
     maxevals = typemax(Int)
-    maxfnevals = typemax(Int)
     strict = true
-    (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
+    (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
 ### ------

--- a/src/Derivative/newton.jl
+++ b/src/Derivative/newton.jl
@@ -1,3 +1,13 @@
+# 1 step taken in set up
+function log_step(l::Tracks, M::AbstractDerivativeMethod, state; init=false)
+    init && push!(l.xfₛ, (state.xn0, state.fxn0))
+    push!(l.xfₛ, (state.xn1, state.fxn1))
+    init && log_iteration(l, 1)
+    !init  && log_iteration(l, 1)
+    nothing
+end
+
+
 """
 
     Roots.Newton()
@@ -32,14 +42,6 @@ struct Newton <: AbstractNewtonLikeMethod end
 
 fn_argout(::AbstractNewtonLikeMethod) = 2
 
-function log_step(l::Tracks, M::AbstractNewtonLikeMethod, state; init=false)
-    init && push!(l.xfₛ, (state.xn0, state.fxn0))
-    push!(l.xfₛ, (state.xn1, state.fxn1))
-    init && log_iteration(l, 1)
-    !init  && log_iteration(l, 1)
-    nothing
-end
-
 
 # we store x0,x1,fx0,fx1 **and** Δ = fx1/f'(x1)
 struct NewtonState{T,S} <: AbstractUnivariateZeroState{T,S}
@@ -66,7 +68,7 @@ end
 
 initial_fncalls(M::Newton) = 2
 
-function update_state(method::Newton, F, o::NewtonState{T,S}, options, l=NullTracks()) where {T,S}
+function update_state(M::Newton, F, o::NewtonState{T,S}, options, l=NullTracks()) where {T,S}
 
     xn0, xn1 = o.xn0, o.xn1
     fxn0, fxn1 = o.fxn0, o.fxn1

--- a/src/DerivativeFree/derivative_free.jl
+++ b/src/DerivativeFree/derivative_free.jl
@@ -1,18 +1,18 @@
 ## Derivative free methods inherit from abstract secant
 
 # init_state(M,F,x) --> call init_state(M,F,x₀,x₁,fx₀, fx₁)
-function init_state(M::AbstractSecant, F::Callable_Function, x)
+function init_state(M::AbstractSecantMethod, F::Callable_Function, x)
     x₀, x₁ = x₀x₁(x)
     fx₀, fx₁ = first(F(x₀)), first(F(x₁))
     state = init_state(M, F, x₀, x₁, fx₀, fx₁)
 end
 
 # initialize from xs, fxs
-function init_state(::AbstractSecant, F, x₀, x₁, fx₀, fx₁)
+function init_state(::AbstractSecantMethod, F, x₀, x₁, fx₀, fx₁)
     UnivariateZeroState(x₁, x₀, fx₁, fx₀)
 end
 
-initial_fncalls(::AbstractSecant) = 2
+initial_fncalls(::AbstractSecantMethod) = 2
 
 
 
@@ -48,7 +48,7 @@ initial_fncalls(::AbstractSecant) = 2
 ## seems to work reasonably well over several different test cases.
 
 @inline function do_guarded_step(
-    M::AbstractSecant,
+    M::AbstractSecantMethod,
     o::AbstractUnivariateZeroState{T,S},
 ) where {T,S}
     x, fx = o.xn1, o.fxn1
@@ -57,7 +57,7 @@ end
 
 # check if we should guard against step for method M; call N if yes, P if not
 function update_state_guarded(
-    M::AbstractSecant,
+    M::AbstractSecantMethod,
     N::AbstractUnivariateZeroMethod,
     P::AbstractUnivariateZeroMethod,
     fs,

--- a/src/DerivativeFree/esser.jl
+++ b/src/DerivativeFree/esser.jl
@@ -27,21 +27,21 @@ find_zero(g, x0, Order2(), verbose=true)        #  22 / 45
 find_zero(g, x0, Roots.Order2B(), verbose=true) #  4 / 10
 ```
 """
-struct Esser <: AbstractSecant end
-struct Order2B <: AbstractSecant end
+struct Esser <: AbstractSecantMethod end
+struct Order2B <: AbstractSecantMethod end
 
 function update_state(
-    method::Order2B,
+    M::Order2B,
     fs,
     o::AbstractUnivariateZeroState,
     options,
     l=NullTracks(),
 )
-    update_state_guarded(method, Secant(), Esser(), fs, o, options, l)
+    update_state_guarded(M, Secant(), Esser(), fs, o, options, l)
 end
 
 function update_state(
-    method::Esser,
+    ::Esser,
     F,
     o::AbstractUnivariateZeroState{T,S},
     options,

--- a/src/DerivativeFree/king.jl
+++ b/src/DerivativeFree/king.jl
@@ -14,8 +14,8 @@ The *asymptotic* error, `eᵢ = xᵢ - α`, is given by
 `eᵢ₊₂ = 1/2⋅G''/G'⋅ eᵢ⋅eᵢ₊₁ + (1/6⋅G'''/G' - (1/2⋅G''/G'))^2⋅eᵢ⋅eᵢ₊₁⋅(eᵢ+eᵢ₊₁)`.
 
 """
-struct King <: AbstractSecant end
-struct Order1B <: AbstractSecant end
+struct King <: AbstractSecantMethod end
+struct Order1B <: AbstractSecantMethod end
 
 struct KingState{T,S} <: AbstractUnivariateZeroState{T,S}
     xn1::T

--- a/src/DerivativeFree/order16.jl
+++ b/src/DerivativeFree/order16.jl
@@ -19,17 +19,17 @@ The error, `eᵢ = xᵢ - α`, is expressed as `eᵢ₊₁ = K⋅eᵢ¹⁶` for 
 in equation (50) of the paper.
 
 """
-struct Order16 <: AbstractSecant end
-struct Thukral16 <: AbstractSecant end
+struct Order16 <: AbstractSecantMethod end
+struct Thukral16 <: AbstractSecantMethod end
 
 function update_state(
-    method::Order16,
+    M::Order16,
     fs,
     o::UnivariateZeroState{T,S},
     options,
     l=NullTracks(),
 ) where {T,S}
-    update_state_guarded(method, Secant(), Thukral16(), fs, o, options, l)
+    update_state_guarded(M, Secant(), Thukral16(), fs, o, options, l)
 end
 
 function update_state(

--- a/src/DerivativeFree/order5.jl
+++ b/src/DerivativeFree/order5.jl
@@ -13,11 +13,11 @@ The error, `eᵢ = xᵢ - α`, satisfies
 `eᵢ₊₁ = K₁ ⋅ K₅ ⋅ M ⋅ eᵢ⁵ + O(eᵢ⁶)`
 
 """
-struct Order5 <: AbstractSecant end
-struct KumarSinghAkanksha <: AbstractSecant end
+struct Order5 <: AbstractSecantMethod end
+struct KumarSinghAkanksha <: AbstractSecantMethod end
 
-function update_state(method::Order5, fs, o::UnivariateZeroState, options, l=NullTracks())
-    update_state_guarded(method, Secant(), KumarSinghAkanksha(), fs, o, options, l)
+function update_state(M::Order5, fs, o::UnivariateZeroState, options, l=NullTracks())
+    update_state_guarded(M, Secant(), KumarSinghAkanksha(), fs, o, options, l)
 end
 
 function update_state(
@@ -70,10 +70,10 @@ function update_state(
     #    nothing
 end
 
-struct Order5Derivative <: AbstractSecant end
+struct Order5Derivative <: AbstractSecantMethod end
 fn_argout(::Order5Derivative) = 2
 function update_state(
-    method::Order5Derivative,
+    m::Order5Derivative,
     f,
     o::AbstractUnivariateZeroState{T,S},
     options,

--- a/src/DerivativeFree/order8.jl
+++ b/src/DerivativeFree/order8.jl
@@ -14,18 +14,18 @@ The error, `eᵢ = xᵢ - α`, is expressed as `eᵢ₊₁ = K ⋅ eᵢ⁸` in
 (2.25) of the paper for an explicit `K`.
 
 """
-struct Order8 <: AbstractSecant end
-struct Thukral8 <: AbstractSecant end
+struct Order8 <: AbstractSecantMethod end
+struct Thukral8 <: AbstractSecantMethod end
 
 ## cf also: https://doi.org/10.1515/tmj-2017-0049
 function update_state(
-    method::Order8,
+    M::Order8,
     fs,
     o::UnivariateZeroState{T,S},
     options,
     l=NullTracks(),
 ) where {T,S}
-    update_state_guarded(method, Secant(), Thukral8(), fs, o, options, l)
+    update_state_guarded(M, Secant(), Thukral8(), fs, o, options, l)
 end
 
 function update_state(

--- a/src/DerivativeFree/secant.jl
+++ b/src/DerivativeFree/secant.jl
@@ -15,7 +15,7 @@ The error, `eᵢ = xᵢ - α`, satisfies
 `eᵢ₊₂ = f[xᵢ₊₁,xᵢ,α] / f[xᵢ₊₁,xᵢ] * (xᵢ₊₁-α) * (xᵢ - α)`.
 
 """
-struct Secant <: AbstractSecant end
+struct Secant <: AbstractSecantMethod end
 const Order1 = Secant
 const Orderφ = Secant
 

--- a/src/DerivativeFree/steffensen.jl
+++ b/src/DerivativeFree/steffensen.jl
@@ -16,21 +16,21 @@ step when `f(x)` is large.
 The error, `eᵢ - α`, satisfies
 `eᵢ₊₁ = f[xᵢ, xᵢ+fᵢ, α] / f[xᵢ,xᵢ+fᵢ] ⋅ (1 - f[xᵢ,α] ⋅ eᵢ²`
 """
-struct Steffensen <: AbstractSecant end
-struct Order2 <: AbstractSecant end
+struct Steffensen <: AbstractSecantMethod end
+struct Order2 <: AbstractSecantMethod end
 
 function update_state(
-    method::Order2,
+    M::Order2,
     fs,
     o::UnivariateZeroState{T,S},
     options,
     l=NullTracks(),
 ) where {T,S}
-    update_state_guarded(method, Secant(), Steffensen(), fs, o, options, l)
+    update_state_guarded(M, Secant(), Steffensen(), fs, o, options, l)
 end
 
 function update_state(
-    method::Steffensen,
+    ::Steffensen,
     F,
     o::AbstractUnivariateZeroState{T,S},
     options,

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -1,14 +1,15 @@
 ### Method types
 abstract type AbstractUnivariateZeroMethod end
 
-abstract type AbstractBracketing <: AbstractUnivariateZeroMethod end
-abstract type AbstractBisection <: AbstractBracketing end
+abstract type AbstractBracketingMethod <: AbstractUnivariateZeroMethod end
+abstract type AbstractBisectionMethod <: AbstractBracketingMethod end
 
-abstract type AbstractNonBracketing <: AbstractUnivariateZeroMethod end
-abstract type AbstractSecant <: AbstractNonBracketing end
+abstract type AbstractNonBracketingMethod <: AbstractUnivariateZeroMethod end
+abstract type AbstractSecantMethod <: AbstractNonBracketingMethod end
 
-abstract type AbstractNewtonLikeMethod <: AbstractNonBracketing  end
-abstract type AbstractHalleyLikeMethod <: AbstractNewtonLikeMethod  end
+abstract type AbstractDerivativeMethod <:AbstractNonBracketingMethod  end
+abstract type AbstractNewtonLikeMethod <: AbstractDerivativeMethod end
+abstract type AbstractHalleyLikeMethod <: AbstractDerivativeMethod  end
 abstract type AbstractΔMethod <: AbstractHalleyLikeMethod end
 
 

--- a/src/alternative_interfaces.jl
+++ b/src/alternative_interfaces.jl
@@ -164,7 +164,7 @@ function fzero(f, x0, M::AbstractUnivariateZeroMethod; kwargs...)
     find_zero(FnWrapper(f), x0, M; kwargs...)
 end
 
-function fzero(f, x0, M::AbstractUnivariateZeroMethod, N::AbstractBracketing; kwargs...)
+function fzero(f, x0, M::AbstractUnivariateZeroMethod, N::AbstractBracketingMethod; kwargs...)
     find_zero(FnWrapper(f), x0, M, N; kwargs...)
 end
 

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -129,8 +129,9 @@ function assess_convergence(::Any, state::AbstractUnivariateZeroState, options)
         return (:f_converged, true)
     end
 
-    # stop when xn1 ~ xn.
-    # in find_zeros there is a check that f could be a zero with a relaxed tolerance
+    # stop when xn1 ≈ xn ( |xₙ₊₁ - xₙ| ≤ max(δₐ, max(|xₙ₊₁|, |xₙ|) δᵣ) )
+    # in find_zeros there is a further check that f could be a zero
+    # with a relaxed tolerance when strict=false
     if isapprox(xn1, xn0, atol=options.xabstol, rtol=options.xreltol)
         return (:x_converged, true)
     end
@@ -145,7 +146,7 @@ end
 When the algorithm terminates, this function decides the stopped value or returns NaN
 """
 function decide_convergence(
-    ::AbstractUnivariateZeroMethod,
+    M::AbstractUnivariateZeroMethod,
     F,
     state::AbstractUnivariateZeroState,
     options,
@@ -153,7 +154,6 @@ function decide_convergence(
 )
     xn0, xn1 = state.xn0, state.xn1
     fxn1 = state.fxn1
-
     val ∈ (:f_converged, :exact_zero, :converged) && return xn1
 
     ## stopping is a heuristic, x_converged can mask issues
@@ -164,55 +164,14 @@ function decide_convergence(
         val == :x_converged && return xn1
         _is_f_approx_0(fxn1, xn1, options.abstol, options.reltol) && return xn1
     else
-        if val ∈ (:x_converged, :not_converged)
-            # |fxn| <= relaxed
-
+        if val == :x_converged
+            _is_f_approx_0(fxn1, xn1, options.abstol, options.reltol, true) && return xn1
+        elseif val == :not_converged
+            # this is the case where runaway can happen
+            ## XXX Need a good heuristic to catch that
             _is_f_approx_0(fxn1, xn1, options.abstol, options.reltol, true) && return xn1
         end
     end
-
-    # if (state.stopped || state.x_converged) && !(state.f_converged)
-    #     ## stopped is a heuristic, x_converged can mask issues
-    #     ## if strict == false, this will also check f(xn) ~ - with a relaxed
-    #     ## tolerance
-
-    #     ## are we at a crossing values?
-    #     ## seems worth a check for 2 fn evals.
-    #     if T <: Real && S <: Real
-    #         for u in (prevfloat(xn1), nextfloat(xn1))
-    #             fu = first(F(u))
-    #             incfn(state)
-    #             if iszero(fu) || _unitless(fu * fxn1) < 0
-    #                 state.message *= "Change of sign at xn identified. "
-    #                 state.f_converged = true
-    #             end
-    #         end
-    #     end
-
-    #     δ = maximum(_unitless, (options.abstol, options.reltol))
-    #     if options.strict || iszero(δ)
-    #         if state.x_converged
-    #             state.f_converged = true
-    #         else
-    #             state.convergence_failed = true
-    #         end
-
-    #     else
-    #         xstar, fxstar = state.xn1, state.fxn1
-    #         if _is_f_approx_0(fxstar, xstar, options.abstol, options.reltol, :relaxed)
-    #             state.xstar, state.fxstar = xstar, fxstar
-    #             msg = "Algorithm stopped early, but |f(xn)| < ϵ^(1/3), where ϵ depends on xn, rtol, and atol. "
-    #             state.message = state.message == "" ? msg : state.message * "\n\t" * msg
-    #             state.f_converged = true
-    #         else
-    #             state.convergence_failed = true
-    #         end
-    #     end
-    # end
-
-    # if !state.f_converged
-    #     state.xstar, state.fxstar = NaN*xn1, NaN*fxn1
-    # end
 
     NaN * xn1
 end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -37,9 +37,6 @@ function init_options(M, T=Float64, S=Float64; kwargs...)
     options
 end
 
-# # reset options to default values
-@deprecate init_options!(options, M) init_options(M)
-
 ## --------------------------------------------------
 
 """

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -5,7 +5,6 @@ struct UnivariateZeroOptions{Q,R,S,T}
     abstol::S
     reltol::T
     maxevals::Int
-    maxfnevals::Int
     strict::Bool
 end
 
@@ -26,14 +25,8 @@ function init_options(M, T=Float64, S=Float64; kwargs...)
         get(d, :atol, get(d, :abstol, defs[3])),
         get(d, :rtol, get(d, :reltol, defs[4])),
         get(d, :maxevals, get(d, :maxsteps, defs[5])),
-        get(d, :maxfnevals, defs[6]),
-        get(d, :strict, defs[7]),
+        get(d, :strict, defs[6]),
     )
-    if haskey(d, :maxfnevals)
-        @warn(
-            "maxfnevals is ignored. See the test for an example to implement this featrue"
-        )
-    end
     options
 end
 
@@ -62,9 +55,8 @@ function default_tolerances(
     atol = 4 * eps(real(float(S))) * oneunit(real(S))
     rtol = 4 * eps(real(float(S))) * one(real(S))
     maxevals = 40
-    maxfnevals = typemax(Int)
     strict = false
-    (xatol, xrtol, atol, rtol, maxevals, maxfnevals, strict)
+    (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
 ## --------------------------------------------------

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -246,6 +246,7 @@ Base.show(io::IO, Z::ZeroProblemIterator) =
 ## init(Z,M,p)
 ## init(M,F,state, [options], [logger])
 ## want p to be a keyword, not positional. Leaving for now.
+## but the positional use is not documented (though annoyingly is being tested)
 function init(
     𝑭𝑿::ZeroProblem,
     M::AbstractUnivariateZeroMethod,
@@ -264,8 +265,8 @@ function init(
 end
 
 function init(𝑭𝑿::ZeroProblem, p′=nothing; kwargs...)
-    M =  length(𝑭𝑿.x₀) == 1 ? (Secant(), AlefeldPotraShi()) : (AlefeldPotraShi(),)
-    init(𝑭𝑿, M...; p = p′, kwargs...)
+    M =  length(𝑭𝑿.x₀) == 1 ? Order0() : AlefeldPotraShi()
+    init(𝑭𝑿, M; p = p′, kwargs...)
 end
 
 function init(

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -11,44 +11,67 @@ in the iterative procedure. (Secant methods can have a tuple specify
 their initial values.) Values must be a subtype of `Number` and have
 methods for `float`, `real`, and `oneunit` defined.
 
-For bracketing intervals, `x0` is specified using a tuple, a vector, or any iterable with `extrema` defined. A bracketing interval, ``[a,b]``, is one where f(a) and f(b) have different signs.
+For bracketing intervals, `x0` is specified using a tuple, a vector,
+or any iterable with `extrema` defined. A bracketing interval,
+``[a,b]``, is one where f(a) and f(b) have different signs.
 
 # Return value
 
-If the algorithm suceeds, the approximate root identified is returned. A `ConvergenceFailed` error is thrown if the algorithm fails. The alternate form `solve(ZeroProblem(f,x0), M)` returns `NaN` in case of failure.
+If the algorithm suceeds, the approximate root identified is
+returned. A `ConvergenceFailed` error is thrown if the algorithm
+fails. The alternate form `solve(ZeroProblem(f,x0), M)` returns `NaN`
+in case of failure.
 
 # Specifying a method
 
 A method is specified to indicate which algorithm to employ:
 
-* There are methods for bisection where a bracket is specified: [`Bisection`](@ref), [`Roots.A42`](@ref), [`Roots.AlefeldPotraShi`](@ref), [`Roots.Brent`](@ref), and [`FalsePosition`](@ref)
+* There are methods where a bracket is specified: [`Bisection`](@ref),
+  [`A42`](@ref), [`AlefeldPotraShi`](@ref),
+  [`Roots.Brent`](@ref), among others. Bisection is the default, but
+  `A42` generally requires far fewer iterations.
 
-* There are several derivative-free methods: cf. [`Order0`](@ref), [`Order1`](@ref) (also [`Roots.Secant`](@ref)), [`Order2`](@ref) (also [`Roots.Steffensen`](@ref)), [`Order5`](@ref), [`Order8`](@ref), and [`Order16`](@ref), where the number indicates the order of the convergence. Methods [`Roots.Order1B`](@ref) and [`Roots.Order2B`](@ref) are useful when the desired zero has a multiplicity.
+* There are several derivative-free methods: cf. [`Order0`](@ref),
+  [`Order1`](@ref) (also [`Roots.Secant`](@ref)), [`Order2`](@ref)
+  (also [`Steffensen`](@ref)), [`Order5`](@ref),
+  [`Order8`](@ref), and [`Order16`](@ref), where the number indicates
+  the order of the convergence. Methods [`Roots.Order1B`](@ref) and
+  [`Roots.Order2B`](@ref) are useful when the desired zero has a
+  multiplicity.
 
-* There are some classical methods where derivatives are required: [`Roots.Newton`](@ref), [`Roots.Halley`](@ref), [`Roots.Schroder`](@ref).
+* There are some classical methods where derivatives are required:
+  [`Roots.Newton`](@ref), [`Roots.Halley`](@ref),
+  [`Roots.Schroder`](@ref), among others.
 
-* The family [`Roots.LithBoonkkampIJzerman{S,D}`](@ref) for different `S` and `D` uses a linear multistep method root finder. The `(2,0)` method is the secant method, `(1,1)` is Newton's method.
+* The family [`Roots.LithBoonkkampIJzerman{S,D}`](@ref) ,for different
+  `S` and `D`, uses a linear multistep method root finder. The `(2,0)`
+  method is the secant method, `(1,1)` is Newton's method.
 
-For more detail, see the help page for each method (e.g., `?Order1`). Non-exported methods must be qualified with module name, as in `?Roots.Schroder`.
+For more detail, see the help page for each method (e.g.,
+`?Order1`). Non-exported methods must be qualified with module name,
+as in `?Roots.Schroder`.
 
 If no method is specified, the default method depends on `x0`:
 
-* If `x0` is a scalar, the default is the slower, but more robust `Order0` method.
+* If `x0` is a scalar, the default is the more robust `Order0` method.
 
-* If `x0` is a tuple, vector, or iterable with `extrema` defined indicating a *bracketing* interval, the `Bisection` method is used. (The exact algorithm depends on the number type and the tolerances.)
+* If `x0` is a tuple, vector, or iterable with `extrema` defined
+  indicating a *bracketing* interval, then `Bisection` method is used.
+
 
 # Specifying the function
 
 The function(s) are passed as the first argument.
 
-For the few methods that use one or more derivatives (`Newton`, `Halley`,
-`Schroder`, `LithBoonkkampIJzerman(S,D)`, and  `Order5Derivative`) a
-tuple of functions is used. For the classical algorithms, a function returning `(f(x), f(x)/f'(x), [f'(x)/f''(x)])` may be used.
+For the few methods that use one or more derivatives (`Newton`,
+`Halley`, `Schroder`, `LithBoonkkampIJzerman(S,D)`, etc.) a tuple of
+functions is used. For the classical algorithms, a function returning
+`(f(x), f(x)/f'(x), [f'(x)/f''(x)])` may be used.
 
 # Optional arguments (tolerances, limit evaluations, tracing)
 
-* `xatol` - absolute tolerance for `x` values. Passed to `isapprox(x_n, x_{n-1})`.
-* `xrtol` - relative tolerance for `x` values. Passed to `isapprox(x_n, x_{n-1})`.
+* `xatol` - absolute tolerance for `x` values.
+* `xrtol` - relative tolerance for `x` values.
 * `atol`  - absolute tolerance for `f(x)` values.
 * `rtol`  - relative tolerance for `f(x)` values.
 * `maxevals`   - limit on maximum number of iterations.
@@ -65,14 +88,16 @@ an answer and `xstar` the floating point realization, it may be that
 `f(xstar) - f(α)  ≈ xstar ⋅  f'(α) ⋅ eps(α)`, so tolerances must be
 appreciated, and at times specified.
 
-For the `Bisection` methods, convergence is guaranteed, so the tolerances are set to be ``0`` by default.
+For the `Bisection` methods, convergence is guaranteed over `Float64`
+values, so the tolerances are set to be ``0`` by default.
 
 If a bracketing method is passed in after the method specification,
 then whenever a bracket is identified during the algorithm, the method
 will switch to the bracketing method to identify the zero. (Bracketing
-methods are mathematically guaranteed to converge, non-bracketing methods may or may not converge.)
-This is what `Order0` does by default, with an initial secant method switching
-to the `AlefeldPotraShi` method should a bracket be encountered.
+methods are mathematically guaranteed to converge, non-bracketing
+methods may or may not converge.)  This is what `Order0` does by
+default, with an initial secant method switching to the
+`AlefeldPotraShi` method should a bracket be encountered.
 
 Note: The order of the method is hinted at in the naming scheme. A
 scheme is order `r` if, with `eᵢ = xᵢ - α`, `eᵢ₊₁ = C⋅eᵢʳ`. If the
@@ -110,7 +135,7 @@ julia> find_zero(sin, 3.0, Order2())              # Use Steffensen method
 julia> find_zero(sin, big(3.0), Order16())        # rapid convergence
 3.141592653589793238462643383279502884197169399375105820974944592307816406286198
 
-julia> find_zero(sin, (3, 4), Roots.A42())      # fewer function calls than Bisection(), in this case
+julia> find_zero(sin, (3, 4), A42())              # fewer function calls than Bisection(), in this case
 3.141592653589793
 
 julia> find_zero(sin, (3, 4), FalsePosition(8))   # 1 of 12 possible algorithms for false position
@@ -181,32 +206,6 @@ end
 find_zero(f, x0::Number; kwargs...) = find_zero(f, x0, Order0(); kwargs...)
 find_zero(f, x0; kwargs...) = find_zero(f, x0, Bisection(); kwargs...)
 
-"""
-    find_zero(M, F, state, [options], [l])
-
-Find zero using method `M`, function(s) `F`, and initial state
-`state`. Returns an approximate zero or `NaN`. Useful when some part
-of the processing pipeline is to be adjusted.
-
-* `M::AbstractUnivariateZeroMethod` a method, such as `Secant()`
-* `F`: A callable object (or tuple of callable objects for certain methods)
-* `state`: An initial state, as created by `init_state` (or `_init_state`).
-* `options::UnivariateZeroOptions`: specification of tolerances
-* `l::AbstractTracks`: used to record steps in algorithm, when requested.
-```
-
-!!! note
-    To be deprecated in favor of `solve!(init(...))`.
-"""
-function find_zero(
-    M::AbstractUnivariateZeroMethod,
-    F,
-    state::AbstractUnivariateZeroState,
-    options::UnivariateZeroOptions=init_options(M, state),
-    l::AbstractTracks=NullTracks(),
-)
-    solve!(init(M, F, state, options, l))
-end
 
 ## ---------------
 
@@ -241,7 +240,7 @@ Base.show(io::IO, Z::ZeroProblemIterator) =
 ## init(Z,p)
 ## init(Z,M,p)
 ## init(M,F,state, [options], [logger])
-## want p to be positional, not named⁺
+## want p to be a keyword, not positional. Leaving for now.
 function init(
     𝑭𝑿::ZeroProblem,
     M::AbstractUnivariateZeroMethod,
@@ -274,52 +273,16 @@ function init(
     ZeroProblemIterator(M, Nothing, Callable_Function(M, F), state, options, l)
 end
 
-# Optional iteration interface to handle looping
-# * returns xₙ or (aₙ, bₙ) depending
-# * throws error on non-convergence
-function Base.iterate(P::ZeroProblemIterator, st=nothing)
-    ## st = (val, (state, ctr, flag, stopped))
-
-    M, F, options, l = P.M, P.F, P.options, P.logger
-
-    if st === nothing
-        state = P.state
-        ctr, flag, stopped = 1, :not_converged, false
-        log_method(l, M)
-        log_step(l, M, state; init=true)
-    else
-        state, ctr, flag, stopped = st
-        ctr += 1
-    end
-
-    stopped && return nothing
-    ctr > options.maxevals && return nothing
-
-    state, stopped = update_state(M, F, state, options, l)
-    log_step(l, M, state)
-
-    flag, stopped = assess_convergence(M, state, options)
-
-    if stopped
-        α = decide_convergence(M, F, state, options, flag)
-        log_last(l, α)
-        isnan(α) && throw(ConvergenceFailed("Algorithm did not converge."))
-    end
-
-    return (last(state,M), (state, ctr, flag, stopped))
-
-end
-
-
 
 """
-    solve(fx::ZeroProblem, [p=nothing]; kwargs...)
-    solve(fx::ZeroProblem, M, [p=nothing]; kwargs...)
-    init(fx::ZeroProblem, [M], [p=nothing];
+    solve(fx::ZeroProblem, [M];kwargs...)
+    init(fx::ZeroProblem, [M];
+         p=nothing,
          verbose=false, tracks=NullTracks(), kwargs...)
     solve!(P::ZeroProblemIterator)
 
-Solve for the zero of a function specified through a  `ZeroProblem` or `ZeroProblemIterator`
+Solve for the zero of a function specified through a `ZeroProblem` or
+`ZeroProblemIterator`
 
 The methods involved with this interface are:
 
@@ -328,10 +291,13 @@ The methods involved with this interface are:
 
 The latter calls the following, which can be useful independently:
 
-* `init`: to initialize an iterator with a method for solution, any adjustments to the default tolerances, and a specification to log the steps or not.
+* `init`: to initialize an iterator with a method for solution, any
+  adjustments to the default tolerances, and a specification to log
+  the steps or not.
 * `solve!` to iterate to convergence.
 
-Returns `NaN`, not an error, when the problem can not be solved. Tested for zero allocations.
+Returns `NaN`, not an error, when the problem can not be
+solved. Tested for zero allocations.
 
 ## Examples:
 
@@ -358,11 +324,13 @@ julia> solve!(problem)
 The default method is `Order1()`, when  `x0` is a number, or `Bisection()` when `x0` is an iterable with 2 or more values.
 
 
-A second position argument for `solve` or `init` is used to specify a different method; keyword arguments can be used to adjust the default tolerances.
+A second positional argument for `solve` or `init` is used to specify
+a different method; keyword arguments can be used to adjust the
+default tolerances.
 
 
 ```jldoctest find_zero
-julia> solve(fx, Order5(), atol=1/100)
+julia> solve(fx, Order5(); atol=1/100)
 3.1425464815525403
 ```
 
@@ -376,7 +344,9 @@ julia> solve!(problem)
 3.1425464815525403
 ```
 
-The  argument `p` may be used if the function(s) to be solved depend on a parameter in their second positional argument (e.g., `f(x,p)`). For example
+The keyword argument `p` may be used if the function(s) to be solved
+depend on a parameter in their second positional argument (e.g.,
+`f(x,p)`). For example
 
 ```jldoctest find_zero
 julia> f(x,p) = exp(-x) - p # to solve p = exp(-x)
@@ -385,7 +355,7 @@ f (generic function with 1 method)
 julia> fx = ZeroProblem(f, 1)
 ZeroProblem{typeof(f), Int64}(f, 1)
 
-julia> solve(fx, 1/2)  # log(2)
+julia> solve(fx; p=1/2)  # log(2)
 0.6931471805599453
 ```
 
@@ -393,7 +363,10 @@ This would be recommended, as there is no recompilation due to the function chan
 
 The argument `verbose=true` for `init` instructs that steps to be logged;
 
-The iterator interface allows for the creation of hybrid solutions, for example, this is essentially how `Order0` is constructed (`Order0` follows secant steps until a bracket is identified, after which it switches to a bracketing algorithm.)
+The iterator interface allows for the creation of hybrid solutions,
+for example, this is essentially how `Order0` is constructed (`Order0`
+follows secant steps until a bracket is identified, after which it
+switches to a bracketing algorithm.)
 
 ```jldoctest find_zero
 julia> function order0(f, x)
@@ -454,33 +427,46 @@ end
 
 # thread verbose through
 """
-    solve(𝐙::ZeroProblem, args...; verbose=false, kwargs...)
+    solve(fx::ZeroProblem, args...; verbose=false, kwargs...)
 
-Disptaches to `solve!(init(𝐙, args...; kwargs...))`. See [`solve!`](@ref) for details.
+Disptaches to `solve!(init(fx, args...; kwargs...))`. See [`solve!`](@ref) for details.
 """
-CommonSolve.solve(F::ZeroProblem, args...; verbose=false, kwargs...) =
-    solve!(init(F, args...; verbose=verbose, kwargs...); verbose=verbose)
+CommonSolve.solve(𝑭𝑿::ZeroProblem, args...; verbose=false, kwargs...) =
+    solve!(init(𝑭𝑿, args...; verbose=verbose, kwargs...); verbose=verbose)
 
-## --------------------------------------------------
-## Framework for setting up an iterative problem for finding a zero
-#
-# In McNamee & Pan (DOI:10.1016/j.camwa.2011.11.015 there are a number of
-# results on efficiencies of a solution, (1/d) log_10(q)
-# Those implemented here are:
-# quadratic cut (Muller) .265 (in a42)
-# Newton() newton = .1505   or 1/2log(2)
-# Order1() secant method .20 (1/1 * log(1.6)
-# FalsePostion(12) Anderson-Bjork [.226, .233]
-# FalsePostion(3) (King?) .264
-# A42() 0.191 but convergence guaranteed
-# Order8() 8th order 4 steps: .225 (log10(8)/4
-# Order16() 16th order 5 steps .240
-# Order5(): 5th order, 4 steps. 0.1747
 
-# A zero is found by specifying:
-# the method to use <: AbstractUnivariateZeroMethod
-# the function(s)
-# the initial state through a value for x either x, [a,b], or (a,b) <: AbstractUnivariateZeroState
-# the options (e.g., tolerances) <: UnivariateZeroOptions
+# Optional iteration interface to handle looping
+# * returns xₙ or (aₙ, bₙ) depending
+# * throws error on non-convergence
+function Base.iterate(P::ZeroProblemIterator, st=nothing)
+    ## st = (val, (state, ctr, flag, stopped))
 
-# The minimal amount needed to add a method, is to define a Method and an update_state method.
+    M, F, options, l = P.M, P.F, P.options, P.logger
+
+    if st === nothing
+        state = P.state
+        ctr, flag, stopped = 1, :not_converged, false
+        log_method(l, M)
+        log_step(l, M, state; init=true)
+    else
+        state, ctr, flag, stopped = st
+        ctr += 1
+    end
+
+    stopped && return nothing
+    ctr > options.maxevals && return nothing
+
+    state, stopped = update_state(M, F, state, options, l)
+    log_step(l, M, state)
+
+    flag, stopped = assess_convergence(M, state, options)
+
+    if stopped
+        α = decide_convergence(M, F, state, options, flag)
+        log_last(l, α)
+        isnan(α) && throw(ConvergenceFailed("Algorithm did not converge."))
+    end
+
+    return (last(state,M), (state, ctr, flag, stopped))
+
+end

--- a/src/order0.jl
+++ b/src/order0.jl
@@ -21,7 +21,7 @@ so for reasonable starting points and functions, this algorithm should be
 superlinear, and relatively robust to non-reasonable starting points.
 
 """
-struct Order0 <: AbstractSecant end
+struct Order0 <: AbstractSecantMethod end
 
 # special case Order0 to be hybrid
 function init(
@@ -41,8 +41,8 @@ end
 ## the keyword p
 function init(
     𝑭𝑿::ZeroProblem,
-    M::AbstractUnivariateZeroMethod,
-    N::AbstractBracketing;
+    M::AbstractNonBracketingMethod,
+    N::AbstractBracketingMethod;
     p=nothing,
     verbose::Bool=false,
     tracks=NullTracks(),
@@ -63,7 +63,7 @@ end
 # * limit steps so as not too far or too near the previous one
 # * if not decreasing, use a quad step upto 4 times to bounce out of trap, if possible
 # First uses M, then N if bracket is identified
-function solve!(𝐙::ZeroProblemIterator{𝐌,𝐍}; verbose=false) where {𝐌,𝐍<:AbstractBracketing}
+function solve!(𝐙::ZeroProblemIterator{𝐌,𝐍}; verbose=false) where {𝐌,𝐍<:AbstractBracketingMethod}
     M, N, F, state, options, l = 𝐙.M, 𝐙.N, 𝐙.F, 𝐙.state, 𝐙.options, 𝐙.logger
 
     incfn(l, 2)
@@ -194,7 +194,7 @@ function find_zero(
     fs,
     x0,
     M::AbstractUnivariateZeroMethod,
-    N::AbstractBracketing;
+    N::AbstractBracketingMethod;
     verbose=false,
     kwargs...,
 )
@@ -204,7 +204,7 @@ end
 
 # Switch to bracketing method
 # deprecate soon, not used
-function run_bisection(N::AbstractBracketing, f, ab, state)
+function run_bisection(N::AbstractBracketingMethod, f, ab, state)
     steps, fnevals = state.steps, state.fnevals
     f = Callable_Function(N, f)
     init_state!(state, N, f; clear=true)

--- a/src/order0.jl
+++ b/src/order0.jl
@@ -201,16 +201,3 @@ function find_zero(
     𝐏 = ZeroProblem(fs, x0)
     solve!(init(𝐏, M, N; verbose=verbose, kwargs...), verbose=verbose)
 end
-
-# Switch to bracketing method
-# deprecate soon, not used
-function run_bisection(N::AbstractBracketingMethod, f, ab, state)
-    steps, fnevals = state.steps, state.fnevals
-    f = Callable_Function(N, f)
-    init_state!(state, N, f; clear=true)
-    find_zero(N, f, state, init_options(N, state))
-    a, b = _extrema(ab)
-    u, v = a > b ? (b, a) : (a, b)
-    state.message *= "Bracketing used over ($u, $v), those steps not shown. "
-    return nothing
-end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -365,7 +365,7 @@ The inital values can be specified as a pair of two values, as in
 is computed, possibly from `fb`.  The basic idea is to follow the
 secant method to convergence unless:
 
-* a bracket is found, in which case bisection is used;
+* a bracket is found, in which case `AlefeldPotraShi` is used;
 
 * the secant method is not converging, in which case a few steps of a
   quadratic method are used to see if that improves matters.
@@ -411,7 +411,7 @@ function dfree(f, xs)
         cnt += 1
 
         if sign(fa) * sign(fb) < 0
-            return bisection(f, a, b)
+            return solve(ZeroProblem(f, (a,b))) # faster than bisection(f, a, b)
         end
 
         # take a secant step
@@ -426,7 +426,7 @@ function dfree(f, xs)
 
         # change sign
         if sign(fgamma) * sign(fb) < 0
-            return bisection(f, gamma, b)
+            return solve(ZeroProblem(f, (gamma, b))) # faster than bisection(f, gamma, b)
         end
 
         # decreasing

--- a/src/state.jl
+++ b/src/state.jl
@@ -27,9 +27,22 @@ function _set(state, xf1, xf0)
     state
 end
 
-# init_state(M, F, state) -- convert
+# init_state(M, F, x; kwargs...)
+# init_state(M, F x₀,x₁,fx₀,fx₁; kwargs...)
+# init_state(M, state, F)
+#
+# A state holds at a minimum:
+#
+# * the values xₙ₋₁, xₙ and f(xₙ₋₁), f(xₙ) along with
+# * some method-specific values
+#
+#
+# A state is initialized with `init_state(M, F, x)` which sets up xₙ₋₁, xₙ, f(xₙ₋₁), f(xₙ)
+# which then calls `init_state(M, F, xₙ₋₁, xₙ, f(xₙ₋₁), f(xₙ))` to finish the initialization
+# to change to a new state use `init_state(M, state, F)`
+
 # basic idea to convert from N to M:
-# Fₘ = copy(M, fₙ)
+# Fₘ = some state
 # stateₘ = init_state(M, stateₙ, Fₘ)
 function init_state(M::AbstractUnivariateZeroMethod, state::AbstractUnivariateZeroState, F)
     init_state(M, F, state.xn0, state.xn1, state.fxn0, state.fxn1)
@@ -45,18 +58,4 @@ function init_state(::AbstractUnivariateZeroMethod, F, x₀, x₁, fx₀, fx₁)
     error("no default method")
 end
 
-Base.last(state::AbstractUnivariateZeroState, M::AbstractUnivariateZeroMethod) = state.xn1
-
-# init_state(M, F, x; kwargs...)
-# init_state(M, F x₀,x₁,fx₀,fx₁; kwargs...)
-# init_state(M, state, F)
-#
-# A state holds at a minimum:
-#
-# * the values xₙ₋₁, xₙ and f(xₙ₋₁), f(xₙ) along with
-# * some method-specific values
-#
-# A state is initialized with `init_state(M, F, x)` which sets up xₙ₋₁, xₙ, f(xₙ₋₁), f(xₙ)
-# which then calls `init_state(M, F, xₙ₋₁, xₙ, f(xₙ₋₁), f(xₙ))` to finish the initialization
-# to change to a new state use `init_state(M, state, F)`
-#
+Base.last(state::AbstractUnivariateZeroState, M::AbstractNonBracketingMethod) = state.xn1

--- a/src/state.jl
+++ b/src/state.jl
@@ -45,6 +45,8 @@ function init_state(::AbstractUnivariateZeroMethod, F, x₀, x₁, fx₀, fx₁)
     error("no default method")
 end
 
+Base.last(state::AbstractUnivariateZeroState, M::AbstractUnivariateZeroMethod) = state.xn1
+
 # init_state(M, F, x; kwargs...)
 # init_state(M, F x₀,x₁,fx₀,fx₁; kwargs...)
 # init_state(M, state, F)

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -127,7 +127,7 @@ Tracks(verbose, tracks, state::AbstractUnivariateZeroState{T,S}) where {T,S} =
     (verbose && isa(tracks, NullTracks)) ? Tracks(T,S) : tracks
 Tracks() = Tracks(Float64, Float64) # give default
 
-function log_step(l::Tracks, M::AbstractNonBracketing, state; init=false)
+function log_step(l::Tracks, M::AbstractNonBracketingMethod, state; init=false)
     init && push!(l.xfₛ, (state.xn0, state.fxn0))
     push!(l.xfₛ, (state.xn1, state.fxn1))
     !init  && log_iteration(l, 1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -167,9 +167,9 @@ function identify_starting_point(a, b, sfxs)
     p1
 end
 
-## ----
-
+## not used
 function unicode_subscript(io, j)
+    error("")
     a = ("⁻", "", "", "₀", "₁", "₂", "₃", "₄", "₅", "₆", "₇", "₈", "₉")
     for i in string(j)
         print(io, a[Int(i) - 44])

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -300,7 +300,9 @@ end
     end
 
     ## test broadcasting semantics with ZeroProblem
-    Z = ZeroProblem((x, p) -> cos(x) - p, pi / 4)
+    ## This assume parameters can be passed in a positional manner, a
+    ## style which is discouraged, as it is confusing
+    Z = ZeroProblem((x, p) -> cos(x) - x/p, pi / 4)
     @test all(solve.(Z, (1, 2)) .≈ (solve(Z, 1), solve(Z, 2)))
 end
 

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -44,15 +44,13 @@ struct Order3_Test <: Roots.AbstractSecantMethod end
     @test @inferred(find_zero(sin, [3, 4])) ≈ π   # Bisection()
 
     ## test tolerance arguments
-    ## xatol, xrtol, atol, rtol, maxevals, maxfneval, strict
+    ## xatol, xrtol, atol, rtol, maxevals, strict
     fn, xstar = x -> sin(x) - x + 1, 1.9345632107520243
     x0, M = 20.0, Order2()
     @test find_zero(fn, x0, M) ≈ xstar   # needs 16 iterations, 33 fn evaluations, difference is exact
 
     # test of maxevals
     @test_throws Roots.ConvergenceFailed find_zero(fn, x0, M, maxevals=2)
-    # test of maxfneval REMOVED
-    # @test_throws Roots.ConvergenceFailed find_zero(fn, x0, M, maxfnevals=2)
 
     # tolerance on f, atol, rtol: f(x) ~ 0
     M = Order2()

--- a/test/test_find_zero.jl
+++ b/test/test_find_zero.jl
@@ -7,7 +7,7 @@ Base.adjoint(f) = x -> ForwardDiff.derivative(f, float(x));
 # for a user-defined method
 import Roots.Setfield
 import Roots.Setfield: @set!
-struct Order3_Test <: Roots.AbstractSecant end
+struct Order3_Test <: Roots.AbstractSecantMethod end
 
 ## Test the interface
 @testset "find_zero interface tests" begin
@@ -201,7 +201,7 @@ end
     fxs = f.(xs)
     M = Bisection()
     state = @inferred(Roots.init_state(M, f, xs..., fxs..., m=3.5, fm=f(3.5)))
-    @test @inferred(find_zero(M, f, state)) ≈ π
+    @test @inferred(solve!(init(M, f, state))) ≈ π
 
     #     ## hybrid
     g1 = x -> exp(x) - x^4
@@ -310,9 +310,7 @@ end
     Ms = [
         Order0(),
         Order1(),
-        Roots.Order1B(),
         Order2(),
-        Roots.Order2B(),
         Order5(),
         Order8(),
         Order16(),
@@ -335,7 +333,7 @@ end
         xn = find_zero(fn, x0, M)
         @test abs(fn(xn)) <= 1e-10
     end
-    for M in [Order2(), Order5(), Order8(), Order16()]
+    for M in [Roots.Order1B(), Order2(), Roots.Order2B(), Order5(), Order8(), Order16()]
         @test_throws Roots.ConvergenceFailed find_zero(fn, x0, M, strict=true)
     end
 
@@ -400,8 +398,7 @@ end
         state = Roots.init_state(M, F, x0)
         options = Roots.init_options(M, state)
         l = Roots.Tracks(state)
-        find_zero(M, F, state, options, l)
-
+        solve(ZeroProblem(lhs, x0), M; tracks=l)
         @test l.steps <= 45 # 15
     end
     test_94()

--- a/test/test_find_zeros.jl
+++ b/test/test_find_zeros.jl
@@ -24,13 +24,13 @@ end
     xrts = find_zeros(F, -5, 20)
     @test length(xrts) == 3
     @test all(azero.((F,), xrts))
-    @test F.n <= 3000
+    @test F.n <= 1500 #3000
 
     F = CallableFunction(x -> cos(x) + cos(2x), 0)
     xrts = find_zeros(F, 0, 4pi)
     @test length(xrts) == 6
     @test all(azero.((F,), xrts))
-    @test F.n <= 5000
+    @test F.n <= 2000 # 5000
 
     T11(x) = 1024x^11 - 2816x^9 + 2816x^7 - 1232x^5 + 220x^3 - 11x
     U9(x) = 512x^9 - 1024x^7 + 672x^5 - 160x^3 + 10x
@@ -39,13 +39,13 @@ end
     xrts = find_zeros(F, -1, 1)
     @test length(xrts) == 11
     @test all(azero.((F,), xrts))
-    @test F.n <= 10_000
+    @test F.n <= 2500 # 10_000
 
     F = CallableFunction(U9, 0)
     xrts = find_zeros(F, -1, 1)
     @test length(xrts) == 9
     @test all(azero.((F,), xrts))
-    @test F.n <= 10_000
+    @test F.n <= 2500 # 10_000
 
     W(n) = x -> prod(x - i for i in 1:n)
     Wi(n) = x -> prod((x - i)^i for i in 1:n)
@@ -54,7 +54,7 @@ end
     xrts = find_zeros(F, -1, 21)
     @test length(xrts) == 20
     @test all(azero.((F,), xrts))
-    @test F.n <= 20_000
+    @test F.n <= 4000 #20_000
 
     F = CallableFunction(Wi(6), 0)
     xrts = find_zeros(F, -1, 7)

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -37,7 +37,6 @@ import Roots.fzero
     @test !(fzero(fn, x0, order=1, xatol=1e-4, atol=1) ≈ xstar)
     @test_throws Roots.ConvergenceFailed fzero(fn, x0, order=1, maxevals=3)
     @test !(fzero(fn, x0, order=1, maxevals=3, atol=1e-3) ≈ xstar)
-    ## @test !(fzero(fn, x0, order=1, maxfnevals=3, atol=1e-3) ≈ xstar) removed maxfnevals
 
     ## Infinities
     ## f(b) = Inf


### PR DESCRIPTION
* change default methods for solve from Secant/Bisection to Order0/AlefeldPotraShi
* remove no-longer used bits (maxfnevals, ...)
* document p as a keyword argument, not positional, though left as positional too
* update iterator interface (not used, but may be useful)
* more consistent naming scheme, variable name usage
* use AlefeldPotraShi instead of bisection in dfree
* tidying