### PR TITLE
add back bisection exact

### DIFF
--- a/test/test_bracketing.jl
+++ b/test/test_bracketing.jl
@@ -219,7 +219,8 @@ avg(x) = sum(x) / length(x)
     ## test for evaluation counts, ideally not so low for these problems
 
     ## exact_bracket
-    Ms = [Roots.Brent(), Roots.A42(), Roots.AlefeldPotraShi(), Roots.Chandrapatla(), Roots.ITP(), Roots.Ridders(), Roots.Bisection()]
+    Ms = [Roots.Brent(), Roots.A42(), Roots.AlefeldPotraShi(), Roots.Chandrapatla(), Roots.ITP(), Roots.Ridders(),
+          Roots.Bisection(), Roots.BisectionExact()]
     results = [run_tests((f, b) -> find_zero(f, b, M), name="$M") for M in Ms]
     maxfailures = maximum([length(result.failures) for result in results])
     maxresidual = maximum([result.maxresidual for result in results])
@@ -311,7 +312,7 @@ end
 
    α = nextfloat(nextfloat(0.0))
    f = x -> x - α
-   for M in (Bisection(),) #Ms XXX NOT A42, AlefeldPotraShi with xatol !==0
+   for M in (Bisection(), Roots.BisectionExact()) #Ms XXX NOT A42, AlefeldPotraShi with xatol !==0
        @test find_zero(f, (-1, 1), M) == α
    end
 


### PR DESCRIPTION
add back `Roots.BisectionExact` as it is more performant than `Bisection` with 0 tolerances over FloatNN types.