### PR TITLE
special case bisection

### DIFF
--- a/src/Bracketing/bisection.jl
+++ b/src/Bracketing/bisection.jl
@@ -153,3 +153,71 @@ function update_state(M::AbstractBisectionMethod, F, o, options, l=NullTracks())
 
     return o, false
 end
+
+
+## Special case default method for `find_zero(f, (a,b))`;  gives ~10% speedup by avoiding assess_convergence/update state dispatch
+function solve!(P::ZeroProblemIterator{𝑴, 𝑵, 𝑭, 𝑺, 𝑶, 𝑳}; verbose=false) where {
+    𝑴 <: Bisection, 𝑵, 𝑭, 𝑺, 𝑶 <: ExactOptions, 𝑳}
+
+    M, F, state, options, l = P.M, P.F, P.state, P.options, P.logger
+
+    val, stopped = :not_converged, false
+    ctr = 1
+    log_step(l, M, state; init=true)
+
+    while !stopped
+
+        a, b = state.xn0, state.xn1
+        fa, fb = state.fxn0, state.fxn1
+
+        ## assess_convergence
+        if nextfloat(a) ≥ b
+            val = :x_converged
+            break
+        end
+
+        if (isnan(fa) || isnan(fb))
+            val = :nan
+            break
+        end
+
+        if (iszero(fa) || iszero(fb))
+            val = :exact_zero
+            break
+        end
+        ctr > options.maxevals && break
+
+        # ----
+        ## update step
+        c = __middle(a, b)
+        fc = F(c)
+        incfn(l)
+
+        if sign(fa) * sign(fc) < 0
+            b, fb = c, fc
+        else
+            a, fa = c, fc
+        end
+
+        ## ----
+        @set! state.xn0 = a
+        @set! state.xn1 = b
+        @set! state.fxn0 = fa
+        @set! state.fxn1 = fb
+
+
+        log_step(l, M, state)
+        ctr += 1
+    end
+
+#    val, stopped = assess_convergence(M, state, options) # udpate val flag
+    α = decide_convergence(M, F, state, options, val)
+
+    log_convergence(l, val)
+    log_method(l, M)
+    log_last(l, α)
+    verbose && display(l)
+
+    α
+
+end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -116,7 +116,7 @@ function is_approx_zero_f(::AbstractBracketingMethod, state::AbstractUnivariateZ
     ϵₐ, ϵᵣ = options.abstol, options.reltol
     u, fu = afb₀ < afb₁ ? (ab₀, afb₀) : (ab₁, afb₁)
     Δ = max(_unitless(ϵₐ), _unitless(u) * ϵᵣ)
-    fu ≤ Δ * oneunit(afb)
+    fu ≤ Δ * oneunit(fu)
 end
 
 function is_approx_zero_f(::AbstractUnivariateZeroMethod, state::AbstractUnivariateZeroState, options::O, relaxed::Any) where {O <: AbstractUnivariateZeroOptions}
@@ -128,7 +128,7 @@ function is_approx_zero_f(::AbstractUnivariateZeroMethod, state::AbstractUnivari
 
 end
 
-function is_approx_zero_f(::AbstractUnivariateZeroMethod, state::AbstractUnivariateZeroState, options::O) where {O <: Union{ExactOptions, FExactOptions}}
+function is_approx_zero_f(::AbstractBracketingMethod, state::AbstractUnivariateZeroState, options::O) where {O <: Union{ExactOptions, FExactOptions}}
     false
 end
 
@@ -203,7 +203,7 @@ function assess_convergence(M::Any, state::AbstractUnivariateZeroState, options)
 end
 
 # speeds up exact f values by just a bit (2% or so) over the above, so guess this is worth it.
-function assess_convergence(M::Any, state::AbstractUnivariateZeroState, options::FExactOptions)
+function assess_convergence(M::Any, state::AbstractUnivariateZeroState, options::Union{ExactOptions,FExactOptions})
 
 #    isnan_f(M, state) && return (:nan, true)
 #    is_exact_zero_f(M, state, options) &&  return (:exact_zero, true)
@@ -219,16 +219,6 @@ function assess_convergence(M::Any, state::AbstractUnivariateZeroState, options:
     abs(b-a) ≤ δₓ && return(:x_converged, true)
 
 
-    return (:not_converged, false)
-end
-
-
-# speeds up exact bisection by about 10% over the above
-function assess_convergence(M::Any, state::AbstractUnivariateZeroState, options::ExactOptions)
-    (isnan(state.fxn1) || isnan(state.fxn0)) && return (:nan, true)
-    (iszero(state.fxn1) || iszero(state.fxn0)) && return (:exact_zero, true)
-    a, b = state.xn0, state.xn1
-    (a < b ? nextfloat(a) >= b : nextfloat(b) >=a ) && return (:x_converged, true)
     return (:not_converged, false)
 end
 


### PR DESCRIPTION
It is more performant to have a special path for the default Bisection. This moves that path from just a convergence check to a method for `solve!`, as it gains a bit more.