### PR TITLE
minor edits, tweaks

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,13 +12,17 @@ primary interface. It supports various algorithms through the
 specification of a method. These include:
 
 * Bisection-like algorithms. For functions where a bracketing interval
-  is known (one where ``f(a)`` and ``f(b)`` have alternate signs), the
-  `Bisection` method can be specified. For most floating point number
-  types, bisection occurs in a manner exploiting floating point
-  storage conventions. For others, an algorithm of Alefeld, Potra, and
-  Shi is used. These methods are guaranteed to converge. Methods
-  include `Bisection`, `Roots.A42`, `Roots.AlefeldPotraShi`,
-  `Roots.Brent`, and ``12``-flavors of `FalsePosition`.
+  is known (one where ``f(a)`` and ``f(b)`` have alternate signs),
+  there are several bracketing methods, including `Bisection`.  For
+  most floating point number types, bisection occurs in a manner
+  exploiting floating point storage conventions leading to an exact
+  zero or a bracketing interval as small as floating point
+  computations allows. Other methods include `Roots.A42`,
+  `Roots.AlefeldPotraShi`, `Roots.Brent`, `Roots.Chandrapatlu`,
+  `Roots.ITP`, `Roots.Ridders`, and ``12``-flavors of
+  `FalsePosition`. The default bracketing method is `Bisection`, as it
+  is more robust to some inputs, but `A42` and `AlefeldPotraShi`
+  typically converge in a few iterations and are more performant.
 
 
 * Several derivative-free methods are implemented. These are specified
@@ -34,10 +38,15 @@ specification of a method. These include:
   multiplicity of the zero.
 
 
-* There are historic methods that require a derivative or two:
-  `Roots.Newton` and `Roots.Halley`.  `Roots.Schroder` provides a
-  quadratic method, like Newton's method, which is independent of the
-  multiplicity of the zero.
+* There are methods that require a derivative or two: `Roots.Newton`,
+  `Roots.Halley` are classical ones, `Roots.QuadraticInverse`,
+  `Roots.ChebyshevLike`, `Roots.SuperHaller` are others.
+  `Roots.Schroder` provides a quadratic method, like Newton's method,
+  which is independent of the multiplicity of the zero. The
+  `Roots.ThukralXB`, `X=2`, `3`, `4`, or `5` are also multiplicity
+  three. The `X` denotes the number of derivatives that need
+  specifying. The `Roots.LithBoonkkampIJzerman{S,D}` methods remember
+  `S` steps and use `D` derivatives.
 
 
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -31,7 +31,7 @@ find_zero
 find_zeros
 ```
 
-### CommonSolve interface
+## CommonSolve interface
 
 The problem-algorithm-solve interface is a pattern popularized in `Julia` by the `DifferentialEquations.jl` suite of packages. This can be used as an alternative to `find_zero`. Unlike `find_zero`, `solve` will return `NaN` on non-convergence.
 
@@ -141,7 +141,7 @@ Roots.LithBoonkkampIJzermanBracket
 
 The order of convergence for most methods is for *simple* zeros, values ``\alpha`` where ``f(x) = (x-\alpha) \cdot g(x)``, with ``g(\alpha)`` being non-zero. For methods which are of order ``k`` for non-simple zeros, usually an additional function call is needed per step. For example, this is the case for `Roots.Newton` as compared to `Roots.Schroder`.
 
-Derivative-free methods for non-simple zeros have the following implemented
+Derivative-free methods for non-simple zeros have the following implemented:
 
 ```@docs
 Roots.King
@@ -258,7 +258,7 @@ When an algorithm returns  a  `NaN` value,  it terminates. This  can  happen nea
     The use of  relative tolerances  to  check  if   ``f(x)  \approx  0`` can lead  to spurious  answers  where  ``x`` is very large   (and  hence the relative  tolerance  is large). The return of  very  large solutions  should  be checked against expectations  of the  answer.
 
 
-Deciding if an algorithm won't  terminate is  done  through  counting the number or  iterations performed; the default  adjusted through `maxevals`. As  most  algorithms are superlinear, convergence happens rapidly near  the answer, but  all the algorithms  can take  a while  to  get near  an  answer, even   when progress  is made. As  such, the maximum must be large enough to consider linear cases, yet small enough to avoid too many steps when an algorithm is non-convergent.
+Deciding if an algorithm won't  terminate is  done  through  counting the number or  iterations performed; the default  adjusted through `maxiters`. As  most  algorithms are superlinear, convergence happens rapidly near  the answer, but  all the algorithms  can take  a while  to  get near  an  answer, even   when progress  is made. As  such, the maximum must be large enough to consider linear cases, yet small enough to avoid too many steps when an algorithm is non-convergent.
 
 
 Convergence criteria are method dependent and are determined by  the  `Roots.assess_convergence`  methods.

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -124,9 +124,9 @@ floating point values is a modification of the bisection method, where
 the midpoint is taken over the bit representation of `a` and `b`.
 
 For big float values, bisection is the default (with non-zero
-tolerances), but its use is definitely not suggested.  (Simple
-bisection over `BigFloat` values can take *many* whereas may take many
-fewer. For the problem of finding a zero of `sin` in the interval
+tolerances), but its use is definitely not suggested. Simple
+bisection over `BigFloat` values can take *many* more
+iterations. For the problem of finding a zero of `sin` in the interval
 `(big(3), big(4))`, the default bisection takes ``252`` iterations,
 whereas the `A42` method takes ``4``.
 

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -62,7 +62,7 @@ julia> x0, M = (0, pi/2), Bisection()
 julia> find_zero(g, x0, M) # as before, solve cos(x) - x = 0 using default p=1
 0.7390851332151607
 
-julia> find_zero(g, x0, M, p=2) # solves cos(x) - x/2 = 0
+julia> find_zero(g, x0, M; p=2) # solves cos(x) - x/2 = 0
 1.0298665293222589
 ```
 
@@ -121,24 +121,24 @@ julia> find_zero(x -> Inf*sign(x), (-Inf, Inf))  # Float64 only
 
 The basic algorithm used for bracketing when the values are simple
 floating point values is a modification of the bisection method, where
-the midpoint is taken over the bit representation of `a` and `b`. For
-big float values, an algorithm due to Alefeld, Potra, and Shi is used.
+the midpoint is taken over the bit representation of `a` and `b`.
 
-```jldoctest roots
-julia> find_zero(sin, (big(3), big(4)))    # uses a different algorithm than for (3,4)
-3.141592653589793238462643383279502884197169399375105820974944592307816406286198
-```
+For big float values, bisection is the default (with non-zero
+tolerances), but its use is definitely not suggested.  (Simple
+bisection over `BigFloat` values can take *many* whereas may take many
+fewer. For the problem of finding a zero of `sin` in the interval
+`(big(3), big(4))`, the default bisection takes ``252`` iterations,
+whereas the `A42` method takes ``4``.
 
-(Simple bisection over `BigFloat` values can take *many* steps.)
-
-The algorithms of Alefeld, Potra, and Shi and the well known algorithm of Brent, also start with a bracketing algorithm. For many problems these will take far fewer steps than the bisection algorithm to reach convergence. These may be called directly. For example,
+The algorithms of Alefeld, Potra, and Shi and the well known algorithm
+of Brent, also start with a bracketing algorithm. For many problems
+these will take far fewer steps than the bisection algorithm to reach
+convergence. These may be called directly. For example,
 
 ```jldoctest roots
 julia> find_zero(sin, (3,4), A42())
 3.141592653589793
 ```
-
-The above call takes ``9`` function evaluations, the default method takes ``53``.
 
 
 By default, bisection will converge to machine tolerance. This may
@@ -274,14 +274,14 @@ To investigate an algorithm and its convergence, the argument
 For some functions, adjusting the default tolerances may be necessary
 to achieve convergence. The tolerances include `atol` and `rtol`, which are
 used to check if $f(x_n) \approx 0$;
-`xatol` and `xrtol`, to check if $x_n \approx x_{n-1}$; and `maxevals`  to limit the
-number of steps in the algorithm.
+`xatol` and `xrtol`, to check if $x_n \approx x_{n-1}$; and `maxiters`  to limit the
+number of iterations in the algorithm.
 
 
 
 ## Classical methods
 
-The package provides some classical methods for root finding:
+The package provides some classical methods for root finding, such as
 `Roots.Newton`, `Roots.Halley`, and `Roots.Schroder`. (Currently
 these are not exported, so must be prefixed with the package name to
 be used.) We can see how each works on a problem studied by Newton.
@@ -1007,7 +1007,7 @@ julia> function Roots.update_state(::Chandrapatla, F, o, options, l=NullTracks()
     b, a, c = o.xn1, o.xn0, o.c
     fb, fa, fc = o.fxn1, o.fxn0, o.fc
 
-    # encoding: a = xₙ, b=xₙ₋₁, c= xₙ₋₂
+    # encoding: a = xₙ, b = xₙ₋₁, c = xₙ₋₂
     ξ = (a - b) / (c - b)
     ϕ = (fa - fb) / (fc - fb)
     ϕ² = ϕ^2
@@ -1038,7 +1038,7 @@ end
 
 ```
 
-This algorithm chooses between an inverse quadratic step or a bisection step depending on the relationship between the computed `ξ` and `Φ`. The tolerances are from the default for `AbstractAcceleratedBisection`, which choose  `eps(T)^2` for the absolute ``x``-tolerance and `eps(t)` for the relative ``x``-tolerance.
+This algorithm chooses between an inverse quadratic step or a bisection step depending on the relationship between the computed `ξ` and `Φ`. The tolerances are from the default for `AbstractBracketingMethod`.
 
 
 To see that the algorithm works, we have:

--- a/src/Bracketing/bisection.jl
+++ b/src/Bracketing/bisection.jl
@@ -74,9 +74,9 @@ function default_tolerances(::AbstractBisectionMethod, ::Type{T}, ::Type{S′}) 
     xrtol = 0 * one(T)
     atol = 0 * oneunit(S)
     rtol = 0 * one(S)
-    maxevals = typemax(Int)
+    maxiters = typemax(Int)
     strict = true
-    (xatol, xrtol, atol, rtol, maxevals, strict)
+    (xatol, xrtol, atol, rtol, maxiters, strict)
 end
 
 # not float uses some non-zero tolerances for `x`
@@ -86,9 +86,9 @@ function default_tolerances(::AbstractBisectionMethod, ::Type{T′}, ::Type{S′
     xrtol = eps(T) * one(T) # unitless
     atol = 0 * oneunit(S)
     rtol = 0 * one(S)
-    maxevals = typemax(Int)
+    maxiters = typemax(Int)
     strict = true
-    (xatol, xrtol, atol, rtol, maxevals, strict)
+    (xatol, xrtol, atol, rtol, maxiters, strict)
 end
 
 
@@ -185,7 +185,7 @@ function solve!(P::ZeroProblemIterator{𝑴, 𝑵, 𝑭, 𝑺, 𝑶, 𝑳}; verb
             val = :exact_zero
             break
         end
-        ctr > options.maxevals && break
+        ctr > options.maxiters && break
 
         # ----
         ## update step

--- a/src/Bracketing/false_position.jl
+++ b/src/Bracketing/false_position.jl
@@ -40,9 +40,9 @@ function default_tolerances(::FalsePosition{12}, ::Type{T}, ::Type{S}) where {T,
     xrtol = eps(real(T))  # unitless
     atol = 4 * eps(real(float(S))) * oneunit(real(S))
     rtol = 4 * eps(real(float(S))) * one(real(S))
-    maxevals = 250
+    maxiters = 250
     strict = false
-    (xatol, xrtol, atol, rtol, maxevals, strict)
+    (xatol, xrtol, atol, rtol, maxiters, strict)
 end
 
 

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -12,7 +12,6 @@ using Setfield
 export fzero, fzeros, secant_method
 
 export find_zero,
-    find_zero!,
     find_zeros,
     ZeroProblem,
     solve,

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -12,7 +12,11 @@ abstract type AbstractNewtonLikeMethod <: AbstractDerivativeMethod end
 abstract type AbstractHalleyLikeMethod <: AbstractDerivativeMethod  end
 abstract type AbstractΔMethod <: AbstractHalleyLikeMethod end
 
-
+# deprecated but not clear way to do so, hence these defintions not to be used
+const AbstractBracketing = AbstractBracketingMethod
+const AbstractBisection = AbstractBisectionMethod
+const AbstractNonBracketing = AbstractNonBracketingMethod
+const AbstractSecant = AbstractSecantMethod
 
 ### State
 abstract type AbstractUnivariateZeroState{T,S} end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -7,7 +7,7 @@ struct UnivariateZeroOptions{Q,R,S,T} <: AbstractUnivariateZeroOptions
     xreltol::R
     abstol::S
     reltol::T
-    maxevals::Int
+    maxiters::Int
     strict::Bool
 end
 
@@ -15,19 +15,19 @@ end
 struct XExactOptions{S,T} <: AbstractUnivariateZeroOptions
     abstol::S
     reltol::T
-    maxevals::Int
+    maxiters::Int
     strict::Bool
 end
 
 struct FExactOptions{S,T} <: AbstractUnivariateZeroOptions
     xabstol::S
     xreltol::T
-    maxevals::Int
+    maxiters::Int
     strict::Bool
 end
 
 struct ExactOptions <: AbstractUnivariateZeroOptions
-    maxevals::Int
+    maxiters::Int
     strict::Bool
 end
 
@@ -45,7 +45,7 @@ function init_options(M, T=Float64, S=Float64; kwargs...)
     δᵣ = get(d, :xrtol, get(d, :xreltol, defs[2]))
     ϵₐ = get(d, :atol, get(d, :abstol, defs[3]))
     ϵᵣ = get(d, :rtol, get(d, :reltol, defs[4]))
-    M = get(d, :maxevals, get(d, :maxsteps, defs[5]))
+    M = get(d, :maxiters, get(d, :maxevals, get(d, :maxsteps, defs[5])))
     strict = get(d, :strict, defs[6])
 
     iszero(δₐ) && iszero(δᵣ) && iszero(ϵₐ) && iszero(ϵᵣ) && return ExactOptions(M, strict)
@@ -66,7 +66,7 @@ The default tolerances for most methods are `xatol=eps(T)`,
 units (absolute tolerances have the units of `x` and `f(x)`; relative
 tolerances are unitless). For `Complex{T}` values, `T` is used.
 
-The number of iterations is limited by `maxevals=40`.
+The number of iterations is limited by `maxiters=40`.
 
 """
 default_tolerances(M::AbstractUnivariateZeroMethod) =
@@ -80,9 +80,9 @@ function default_tolerances(
     xrtol = eps(real(T))  # unitless
     atol = 4 * eps(real(float(S))) * oneunit(real(S))
     rtol = 4 * eps(real(float(S))) * one(real(S))
-    maxevals = 40
+    maxiters = 40
     strict = false
-    (xatol, xrtol, atol, rtol, maxevals, strict)
+    (xatol, xrtol, atol, rtol, maxiters, strict)
 end
 
 ## --------------------------------------------------

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -1,6 +1,6 @@
 """
 
-    find_zero(f, x0, M, [N::AbstractBracketing]; kwargs...)
+    find_zero(f, x0, M, [N::AbstractBracketingMethod]; kwargs...)
 
 Interface to one of several methods for finding zeros of a univariate function, e.g. solving ``f(x)=0``.
 
@@ -56,8 +56,9 @@ If no method is specified, the default method depends on `x0`:
 * If `x0` is a scalar, the default is the more robust `Order0` method.
 
 * If `x0` is a tuple, vector, or iterable with `extrema` defined
-  indicating a *bracketing* interval, then `Bisection` method is used.
+  indicating a *bracketing* interval, then the `Bisection` method is used.
 
+The default methods are chosen to be robust; they may not be as efficient as some others.
 
 # Specifying the function
 
@@ -74,7 +75,7 @@ functions is used. For the classical algorithms, a function returning
 * `xrtol` - relative tolerance for `x` values.
 * `atol`  - absolute tolerance for `f(x)` values.
 * `rtol`  - relative tolerance for `f(x)` values.
-* `maxevals`   - limit on maximum number of iterations.
+* `maxiters`   - limit on maximum number of iterations.
 * `strict` - if `false` (the default), when the algorithm stops, possible zeros are checked with a relaxed tolerance.
 * `verbose` - if `true` a trace of the algorithm will be shown on successful completion. See the internal [`Tracks`](@ref) object to save this trace.
 
@@ -169,7 +170,7 @@ julia> x0, xstar = 1.0,  1.112243913023029;
 julia> find_zero(fn, x0, Order2()) ≈ xstar
 true
 
-julia> find_zero(fn, x0, Order2(), maxevals=3)    # need more steps to converge
+julia> find_zero(fn, x0, Order2(), maxiters=3)    # need more steps to converge
 ERROR: Roots.ConvergenceFailed("Algorithm failed to converge")
 [...]
 ```
@@ -410,7 +411,7 @@ function solve!(P::ZeroProblemIterator; verbose=false)
     while !stopped
         val, stopped = assess_convergence(M, state, options)
         stopped && break
-        ctr > options.maxevals && break
+        ctr > options.maxiters && break
 
         state, stopped = update_state(M, F, state, options, l)
 
@@ -459,7 +460,7 @@ function Base.iterate(P::ZeroProblemIterator, st=nothing)
     end
 
     stopped && return nothing
-    ctr > options.maxevals && return nothing
+    ctr > options.maxiters && return nothing
 
     state, stopped = update_state(M, F, state, options, l)
     log_step(l, M, state)

--- a/src/hybrid.jl
+++ b/src/hybrid.jl
@@ -44,7 +44,7 @@ function solve!(𝐙::ZeroProblemIterator{𝐌,𝐍}; verbose=false) where {𝐌
         flag, converged = assess_convergence(M, state, options)
 
         converged && break
-        ctr >= options.maxevals && break
+        ctr >= options.maxiters && break
 
         state0 = state
         state0, stopped = update_state(M, F, state0, options) # state0 is proposed step

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,6 +20,7 @@ nan(::Type{Float16}) = NaN16
 nan(::Type{Float32}) = NaN32
 nan(::Type{Float64}) = NaN
 nan(x::T) where {T<:Number} = NaN * one(T)
+nan(x::Type{T}) where {T <: Number} = NaN * one(T)
 nan(::Any) = NaN
 
 ## issue with approx derivative


### PR DESCRIPTION
* use `maxiters` over `maxevals` (it is more standard) but allow `maxevals` if specified.
* clean up some docstrings