### PR TITLE
rework default bracketing method; add find_zerov

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,9 +20,10 @@ specification of a method. These include:
   computations allows. Other methods include `Roots.A42`,
   `Roots.AlefeldPotraShi`, `Roots.Brent`, `Roots.Chandrapatlu`,
   `Roots.ITP`, `Roots.Ridders`, and ``12``-flavors of
-  `FalsePosition`. The default bracketing method is `Bisection`, as it
-  is more robust to some inputs, but `A42` and `AlefeldPotraShi`
-  typically converge in a few iterations and are more performant.
+  `FalsePosition`. The default bracketing method is `Bisection` for
+  the basic floating-point types, as it is more robust to some inputs,
+  but `A42` and `AlefeldPotraShi` typically converge in a few
+  iterations and are more performant.
 
 
 * Several derivative-free methods are implemented. These are specified

--- a/src/Bracketing/bisection.jl
+++ b/src/Bracketing/bisection.jl
@@ -106,7 +106,6 @@ function _middle(x, y)
         __middle(a, b)
     end
 end
-
 ## find middle assuming a,b same sign, finite
 ## Alternative "mean" definition that operates on the binary representation
 ## of a float. Using this definition, bisection will never take more than

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -252,3 +252,18 @@ function show_tracks(io::IO, s::Tracks, M::AbstractUnivariateZeroMethod)
     println(io, "")
 
 end
+
+
+## needs better name, but is this useful?
+"""
+    find_zerov(f, x, M; kwargs...)
+
+Run `find_zero` return a `Tracks` object, not the value, which can be extracted via the `last` method.
+"""
+function find_zerov(f, x, M; verbose=nothing, kwargs...)
+    Z = init(ZeroProblem(f,x), M; verbose=true, kwargs...)
+    solve!(Z)
+    Z.logger
+end
+find_zerov(f, x; verbose=nothing, kwargs...) =
+    find_zerov(f, x, find_zero_default_method(x); kwargs...)


### PR DESCRIPTION
In issue #314 it was pointed out that `ForwardDiff` + `Bisection` has issues. This PR changes the default behavior for `find_zero(f, (a,b))` to use either `Bisection` or `A42` depending on the type of  `(a,b)` (as it always had been). This is breaking, but treated as a bug fix as v2.0.0 broke the code in Bijectors.

It also adds a (poorly named) method `find_zerov` to return the `Tracks` object in place of the solution and updates the doc string for `find_zero`.