### PR TITLE
Bump Setfield Compat to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -9,7 +9,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 CommonSolve = "0.1, 0.2"
-Setfield = "0.7, 0.8"
+Setfield = "0.7, 0.8, 1"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
Hello - I'm getting a transitive package limitation via this package with  Setfield. Can this be bumped? 

It's basically the same: https://github.com/jw3126/Setfield.jl/compare/v0.8.2...v1.0.0