### PR TITLE
Improve ChainRules definitions

### DIFF
--- a/src/chain_rules.jl
+++ b/src/chain_rules.jl
@@ -42,7 +42,7 @@ function ChainRulesCore.rrule(
 
     xᵅ = solve(ZP, M, p; kwargs...)
 
-    f(x, p) = first(Callable_Function(M, ZP.F, p), x)
+    f(x, p) = first(Callable_Function(M, ZP.F, p)(x))
     _, pullback_f = ChainRulesCore.rrule_via_ad(rc, f, xᵅ, p)
     _, fx, fp = pullback_f(true)
     yp = -fp/fx


### PR DESCRIPTION
This PR improves the ChainRules definitions. It fixes some issues with the frule definition and simplifies the frule and rrule definitions by removing unnecessary functions (and hence the amount of boxed values) and more precomputations outside of the pullback.

Still needs tests with ChainRulesTestUtils to ensure that rrule and frule are implemented correctly. I assume some type inference checks might still fail due to closures.