### PR TITLE
Add tests with ChainRulesTestUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ julia = "1.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
@@ -26,4 +27,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["JSON", "SpecialFunctions", "Statistics", "Test", "BenchmarkTools", "ForwardDiff", "Polynomials", "Unitful", "Zygote"]
+test = ["ChainRulesTestUtils", "JSON", "SpecialFunctions", "Statistics", "Test", "BenchmarkTools", "ForwardDiff", "Polynomials", "Unitful", "Zygote"]

--- a/src/chain_rules.jl
+++ b/src/chain_rules.jl
@@ -3,8 +3,6 @@
 # ∇f = 0 => ∂/∂ₓ f(xᵅ, p) ⋅ ∂xᵅ/∂ₚ + ∂/∂ₚf(x\^α, p) ⋅ I = 0
 # or ∂xᵅ/∂ₚ = - ∂/∂ₚ f(xᵅ, p)  / ∂/∂ₓ f(xᵅ, p)
 
-# does this work?
-# It doesn't pass a few of the tests of ChainRulesTestUtils
 function ChainRulesCore.frule(
     config::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasForwardsMode},
     (_, _, _, Δp),
@@ -43,7 +41,7 @@ function ChainRulesCore.rrule(
     _, fx, fp = pullback_f(true)
     yp = -fp / fx
 
-    function pullback_solve_ZeroProblem(dy::Real)
+    function pullback_solve_ZeroProblem(dy)
         dp = yp * dy
         return (
             ChainRulesCore.NoTangent(),

--- a/test/test_chain_rules.jl
+++ b/test/test_chain_rules.jl
@@ -14,7 +14,9 @@ using Test
     f(x, p) = log(x) - p
     test_frule(solve, ZeroProblem(f, 1), Order1(), 1.0; check_inferred=false)
     test_rrule(solve, ZeroProblem(f, 1), Order1(), 1.0; check_inferred=false)
-    test_rrule(Zygote.ZygoteRuleConfig(), solve, ZeroProblem(f, 1), Order1(), 1.0)
+    if isdefined(Zygote, :ZygoteRuleConfig)
+        test_rrule(Zygote.ZygoteRuleConfig(), solve, ZeroProblem(f, 1), Order1(), 1.0)
+    end
     F(p) = find_zero(f, 1, Order1(), p)
     @test first(Zygote.gradient(F, 1)) ≈ exp(1)
 
@@ -28,7 +30,9 @@ using Test
     fx(x, p) = 1 / x
     test_frule(solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0; check_inferred=false)
     test_rrule(solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0; check_inferred=false)
-    test_rrule(Zygote.ZygoteRuleConfig(), solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0)
+    if isdefined(Zygote, :ZygoteRuleConfig)
+        test_rrule(Zygote.ZygoteRuleConfig(), solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0)
+    end
     F2(p) = find_zero((f, fx), 1, Roots.Newton(), p)
     @test first(Zygote.gradient(F2, 1)) ≈ exp(1)
 

--- a/test/test_chain_rules.jl
+++ b/test/test_chain_rules.jl
@@ -6,12 +6,15 @@ using Test
 # issue #325 add frule, rrule
 
 @testset "Test frule and rrule" begin
-    # Type inference tests of `test_frule` and `test_rrule` fail currently
+    # Type inference tests of `test_frule` and `test_rrule` with the default
+    # rule config `ChainRulesTestUtils.TestConfig()` fail due to an issue
+    # with ChainRulesTestUtils: https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/246
 
     # single function
     f(x, p) = log(x) - p
     test_frule(solve, ZeroProblem(f, 1), Order1(), 1.0; check_inferred=false)
     test_rrule(solve, ZeroProblem(f, 1), Order1(), 1.0; check_inferred=false)
+    test_rrule(Zygote.ZygoteRuleConfig(), solve, ZeroProblem(f, 1), Order1(), 1.0)
     F(p) = find_zero(f, 1, Order1(), p)
     @test first(Zygote.gradient(F, 1)) ≈ exp(1)
 
@@ -25,6 +28,7 @@ using Test
     fx(x, p) = 1 / x
     test_frule(solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0; check_inferred=false)
     test_rrule(solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0; check_inferred=false)
+    test_rrule(Zygote.ZygoteRuleConfig(), solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0)
     F2(p) = find_zero((f, fx), 1, Roots.Newton(), p)
     @test first(Zygote.gradient(F2, 1)) ≈ exp(1)
 

--- a/test/test_chain_rules.jl
+++ b/test/test_chain_rules.jl
@@ -1,25 +1,36 @@
 using Roots
+using ChainRulesTestUtils
 using Zygote
 using Test
 
 # issue #325 add frule, rrule
 
-@testset "Test rrule" begin
+@testset "Test frule and rrule" begin
+    # Type inference tests of `test_frule` and `test_rrule` fail currently
 
     # single function
     f(x, p) = log(x) - p
+    test_frule(solve, ZeroProblem(f, 1), Order1(), 1.0; check_inferred=false)
+    test_rrule(solve, ZeroProblem(f, 1), Order1(), 1.0; check_inferred=false)
     F(p) = find_zero(f, 1, Order1(), p)
     @test first(Zygote.gradient(F, 1)) ≈ exp(1)
 
     g(x, p) = x^2 - p[1] * x - p[2]
+    test_frule(solve, ZeroProblem(g, 1), Order1(), [0.0, 4.0]; check_inferred=false)
+    test_rrule(solve, ZeroProblem(g, 1), Order1(), [0.0, 4.0]; check_inferred=false)
     G(p) = find_zero(g, 1, Order1(), p)
     @test first(Zygote.gradient(G, [0, 4])) ≈ [1 / 2, 1 / 4]
 
+    # a tuple of functions 
     fx(x, p) = 1 / x
+    test_frule(solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0; check_inferred=false)
+    test_rrule(solve, ZeroProblem((f, fx), 1), Roots.Newton(), 1.0; check_inferred=false)
     F2(p) = find_zero((f, fx), 1, Roots.Newton(), p)
     @test first(Zygote.gradient(F2, 1)) ≈ exp(1)
 
-    gp(x, p) = 2x - p[1]
-    G2(p) = find_zero((g, gp), 1, Roots.Newton(), p)
+    gx(x, p) = 2x - p[1]
+    test_frule(solve, ZeroProblem((g, gx), 1), Roots.Newton(), [0.0, 4.0]; check_inferred=false)
+    test_rrule(solve, ZeroProblem((g, gx), 1), Roots.Newton(), [0.0, 4.0]; check_inferred=false)
+    G2(p) = find_zero((g, gx), 1, Roots.Newton(), p)
     @test first(Zygote.gradient(G2, [0, 4])) ≈ [1 / 2, 1 / 4]
 end


### PR DESCRIPTION
As I assumed, unfortunately currently type inference checks fail. I haven't checked in detail what the underlying issue is. The tests with ChainRulesTestUtils show at least that otherwise the CR interface is implemented correctly.