### PR TITLE
clean up docs; BracketedSchroder; IntervalRoots extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,11 +16,6 @@ IntervalRootFinding = "0.5"
 Setfield = "0.7, 0.8, 1"
 julia = "1.0"
 
-
-[weakdeps]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
-
 [extensions]
 RootsForwardDiffExt = "ForwardDiff"
 RootsIntervalRootFindingExt = "IntervalRootFinding"

--- a/Project.toml
+++ b/Project.toml
@@ -8,14 +8,6 @@ CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
-[weakdeps]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
-
-[extensions]
-RootsForwardDiffExt = "ForwardDiff"
-RootsIntervalRootFindingExt = "IntervalRootFinding"
-
 [compat]
 ChainRulesCore = "1"
 CommonSolve = "0.1, 0.2"
@@ -23,6 +15,15 @@ ForwardDiff = "0.10"
 IntervalRootFinding = "0.5"
 Setfield = "0.7, 0.8, 1"
 julia = "1.0"
+
+
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+
+[extensions]
+RootsForwardDiffExt = "ForwardDiff"
+RootsIntervalRootFindingExt = "IntervalRootFinding"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -40,3 +41,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
 test = ["Aqua", "ChainRulesTestUtils", "JSON", "SpecialFunctions", "Statistics", "Test", "BenchmarkTools", "ForwardDiff", "Polynomials", "Unitful", "Zygote"]
+
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"

--- a/Project.toml
+++ b/Project.toml
@@ -8,21 +8,28 @@ CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+
+[extensions]
+RootsForwardDiffExt = "ForwardDiff"
+RootsIntervalRootFindingExt = "IntervalRootFinding"
+
 [compat]
 ChainRulesCore = "1"
 CommonSolve = "0.1, 0.2"
 ForwardDiff = "0.10"
+IntervalRootFinding = "0.5"
 Setfield = "0.7, 0.8, 1"
 julia = "1.0"
-
-[extensions]
-RootsForwardDiffExt = "ForwardDiff"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -33,6 +40,3 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
 test = ["Aqua", "ChainRulesTestUtils", "JSON", "SpecialFunctions", "Statistics", "Test", "BenchmarkTools", "ForwardDiff", "Polynomials", "Unitful", "Zygote"]
-
-[weakdeps]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -135,6 +135,9 @@ Roots.Ridders
 Roots.ITP
 FalsePosition
 Roots.LithBoonkkampIJzermanBracket
+Roots.BracketedHalley
+Roots.BracketedChebyshev
+Roots.BracketedSchroder
 ```
 
 ## Non-simple zeros

--- a/ext/RootsIntervalRootFindingExt.jl
+++ b/ext/RootsIntervalRootFindingExt.jl
@@ -1,0 +1,22 @@
+module RootsIntervalRootFindingExt
+
+using IntervalRootFinding
+using Roots
+
+
+function Roots.find_zeros(f, x0::IntervalRootFinding.Interval{T′}, M=IntervalRootFinding.Newton; kwargs...) where {T′}
+
+    rts = IntervalRootFinding.roots(f, x0, M)
+    T = float(T′)
+    unique_roots = T[find_zero(f, (interval(r).lo, interval(r).hi)) for r ∈ rts if r.status == :unique]
+    unknown = Interval{T}[interval(r) for r ∈ rts if r.status != :unique]
+
+    (zeros = unique_roots, unknown=unknown)
+end
+
+Roots.find_zeros(f, x0::IntervalRootFinding.Interval, M::Roots.Newton; kwargs...) =
+    Roots.find_zeros(f, x0, IntervalRootFinding.Newton)
+Roots.find_zeros(f, x0::IntervalRootFinding.Interval, M::Roots.Bisection; kwargs...) =
+    Roots.find_zeros(f, x0, IntervalRootFinding.Bisection)
+
+end

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -278,7 +278,8 @@ The asymptotic efficiency index, ``q^{1/k}``, is ``(2 + 7^{1/2})^{1/3} = 1.6686.
 Originally by John Travers.
 
 !!! note
-   The paper refenced above shows that for a continuously differentiable ``f`` over ``[a,b]`` with a simple root  the algorithm terminates at a zero or asymptotically the steps are of the inverse cubic type (Lemma 5.1). This is proved under an assumption that ``f`` is four-times continuously differentiable.
+
+    The paper refenced above shows that for a continuously differentiable ``f`` over ``[a,b]`` with a simple root  the algorithm terminates at a zero or asymptotically the steps are of the inverse cubic type (Lemma 5.1). This is proved under an assumption that ``f`` is four-times continuously differentiable.
 
 """
 const A42 = A57{2}

--- a/src/find_zeros.jl
+++ b/src/find_zeros.jl
@@ -266,6 +266,13 @@ The algorithm is derived from one in a
     Bisection, on the other hand, only will look for a zero if the two endpoints have different signs,
     a much more rigid condition for a potential zero.
 
+!!! note "`IntervalRootFinding` extension"
+    As of version `1.9` an extension is provided so that when the `IntervalRootFinding` package is loaded,
+    the `find_zeros` function will call `IntervalRootFinding.roots` to find the isolating brackets and
+    `find_zero` to find the roots, when possible, **if** the interval is specified as an `Interval` object,
+    as created by `-1..1`, say.
+
+
 For example, this function (due to `@truculentmath`) is particularly tricky, as it is positive at every floating point number, but has two zeros (the vertical asymptote at `15//11` is only negative within adjacent floating point values):
 
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,4 +27,4 @@ VERSION >= v"1.6.0" && include("./test_allocations.jl")
 #include("./runbenchmarks.jl")
 #include("./test_derivative_free_interactive.jl")
 
-Aqua.test_all(Roots; ambiguities=false)
+Aqua.test_all(Roots; ambiguities=false, project_toml_formatting = false)


### PR DESCRIPTION
* clean up docs slightly
* added `BracketedSchroder` as an alternative for the bracketing methods, useful for non-simple zeros
* Added extension for `IntervalRootFinding` overriding `find_zeros` when the interval is passed using an `IntervalRootFinding.Interval`.