### PR TITLE
Use direct links instead of `tinyurl`

### DIFF
--- a/src/Derivative/halley_like.jl
+++ b/src/Derivative/halley_like.jl
@@ -59,7 +59,7 @@ end
 """
     Roots.Halley()
 
-Implements Halley's [method](http://tinyurl.com/yd83eytb), `xᵢ₊₁ = xᵢ
+Implements Halley's [method](https://en.wikipedia.org/wiki/Halley%27s_method), `xᵢ₊₁ = xᵢ
 - (f/f')(xᵢ) * (1 - (f/f')(xᵢ) * (f''/f')(xᵢ) * 1/2)^(-1)` This method
 is cubically converging, it requires ``3`` function calls per
 step. Halley's method finds `xₙ₊₁` as the zero of a hyperbola at the

--- a/src/Derivative/newton.jl
+++ b/src/Derivative/newton.jl
@@ -11,7 +11,7 @@ end
 
     Roots.Newton()
 
-Implements Newton's [method](http://tinyurl.com/b4d7vls):
+Implements Newton's [method](https://en.wikipedia.org/wiki/Newton%27s_method):
 `xᵢ₊₁ =  xᵢ - f(xᵢ)/f'(xᵢ)`.  This is a quadratically convergent method requiring
 one derivative and two function calls per step.
 


### PR DESCRIPTION
I don't see a reason to link via `tinyurl` instead directly to Wikipedia.
If I'm missing something, feel free to close that PR.