### PR TITLE
use `guarded_secant_step` on AlefeldPotraShi

### DIFF
--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -58,7 +58,7 @@ function init_state(::AbstractAlefeldPotraShi, F, x₀, x₁, fx₀, fx₁;
     end
 
     if c === nothing # need c, fc to be defined if one is
-        c = a < zero(a) < b ?  _middle(a,b) : secant_step(a,b,fa,fb)
+        c = a < zero(a) < b ?  _middle(a,b) : first(guarded_secant_step(a,b,fa,fb))
         fc= first(F(c))
     end
 


### PR DESCRIPTION
~~should solve #369~~ not yet, but helps on this edge case:
```
g4(x) = sqrt(abs(x^2-1))/(x*sign(x^2-1))
prob3 = ZeroProblem(g4,( 1.688277135825698, 1.6882771358256985))
solve(prob3)

#master:
0.8825741897640906

#PR
ERROR: ArgumentError: The interval [a,b] is not a bracketing interval.
You need f(a) and f(b) to have different signs (f(a) * f(b) < 0).
Consider a different bracket or try fzero(f, c) with an initial guess c.
```
seems to solve the discrepancy shown in #368 