### PR TITLE
Lith patch

### DIFF
--- a/src/Derivative/lith.jl
+++ b/src/Derivative/lith.jl
@@ -133,11 +133,15 @@ log_step(l::Tracks, M::LithBoonkkampIJzerman, state; init=false) =
 
 # return f^(i-1)(x) for i in 0:N-1; not the same as default eval call
 function evalf(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P<:Nothing}
-    map(f -> f(x), F.f) #recommended on Slack to not allocate
+    fi = map(f -> f(x), F.f) #recommended on Slack to not allocate
+    R = typeof(float(first(fi)))
+    convert(NTuple{N,R},fi)
 end
 
 function evalf(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P}
     map(f -> f(x,F.p), F.f)
+    R = typeof(float(first(fi)))
+    convert(NTuple{N,R},fi)
 end
 
 #specializations for N = 1,2,3,4,5,6

--- a/src/Derivative/lith.jl
+++ b/src/Derivative/lith.jl
@@ -131,29 +131,90 @@ end
 log_step(l::Tracks, M::LithBoonkkampIJzerman, state; init=false) =
     log_step(l, Secant(), state; init=init)
 
-# return f^(i-1)(x); not the same as default eval call
-function evalf(F::Callable_Function{S,T,𝑭,P}, x, i) where {N,S<:Val{N},T<:Val{true},𝑭,P}
-    F.f[i](x)
+# return f^(i-1)(x) for i in 0:N-1; not the same as default eval call
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P<:Nothing}
+    map(f -> f(x), F.f) #recommended on Slack to not allocate
 end
-function evalf(F::Callable_Function{S,T,𝑭,P}, x, i) where {S<:Val{1},T<:Val{false},𝑭,P}
-    F.f(x)
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P}
+    map(f -> f(x,F.p), F.f)
 end
-evalf(::Callable_Function, x, i) = throw(
-    ArgumentError(
-        "LithBoonkkampIJzerman expects functions to be defined singly or as tuples",
-    ),
-)
+
+#specializations for N = 1,2,3,4,5,6
+## lmm(::Roots.LithBoonkkampIJzerman{1, D}) is defined up unitl D = 6, so specialize those
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {S<:Val{1},T<:Val{false},𝑭,P}
+    F(x)
+end
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {S<:Val{2},T<:Val{false},𝑭,P}
+    f,Δ = F(x)
+    f′ = f/Δ
+    (f,f′)
+end
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {S<:Val{3},T<:Val{false},𝑭,P}
+    f,Δ = F(x)
+    Δ₁,Δ₂ = Δ
+    f′ = f/Δ₁
+    f′′ = f′/Δ₂
+    (f,f′,f′′)
+end
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {S<:Val{4},T<:Val{false},𝑭,P}
+    f,Δ = F(x)
+    Δ₁,Δ₂,Δ₃ = Δ
+    f′ = f/Δ₁
+    f′′ = f′/Δ₂
+    f′′′ = f′′/Δ₃
+    (f,f′,f′′,f′′′)
+end
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {S<:Val{5},T<:Val{false},𝑭,P}
+    f,Δ = F(x)
+    Δ₁,Δ₂,Δ₃,Δ₄ = Δ
+    f′ = f/Δ₁
+    f′′ = f′/Δ₂
+    f′′′ = f′′/Δ₃
+    f′′′′ = f′′′/Δ₄
+    (f,f′,f′′,f′′′,f′′′′)
+end
+
+function evalf(F::Callable_Function{S,T,𝑭,P},x) where {S<:Val{6},T<:Val{false},𝑭,P}
+    f,Δ = F(x)
+    Δ₁,Δ₂,Δ₃,Δ₄,Δ₅ = Δ
+    f′ = f/Δ₁
+    f′′ = f′/Δ₂
+    f′′′ = f′′/Δ₃
+    f′′′′ = f′′′/Δ₄
+    f′′′′′ = f′′′′/Δ₅
+    (f,f′,f′′,f′′′,f′′′′,f′′′′′)
+end
+
+#function to obtain just the first value. optimized in case of tuple function
+function only_f(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P}
+    return F.f[1](x,F.p)
+end
+
+function only_f(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P<:Nothing}
+    return F.f[1](x)
+end
+
+function only_f(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{false},𝑭,P}
+    return first(F(x))
+end
 
 function init_state(L::LithBoonkkampIJzerman{S,0}, F::Callable_Function, x) where {S}
     x₀, x₁ = x₀x₁(x)
-    fx₀, fx₁ = evalf(F, x₀, 1), evalf(F, x₁, 1)
-    state = init_state(L, F, x₀, x₁, fx₀, fx₁)
+    fx₀, fx₁ = only_f(F, x₀), only_f(F, x₁)
+    state = init_state(L, F, x₀, x₁, fx₀, fx₁, nothing)
 end
 
 function init_state(L::LithBoonkkampIJzerman{S,D}, F::Callable_Function, x) where {S,D}
     x₀ = float(first(x))
-    fx₀ = evalf(F, x₀, 1)
-    state = init_state(L, F, nan(x₀), x₀, nan(fx₀), fx₀)
+    ys₀ = evalf(F, x₀)
+    fx₀ = first(ys₀)
+    state = init_state(L, F, nan(x₀), x₀, nan(fx₀), fx₀, ys₀)
 end
 
 function init_state(
@@ -163,8 +224,9 @@ function init_state(
     x₁::R,
     fx₀,
     fx₁::T,
+    ys₀
 ) where {S,D,R,T}
-    xs, ys = init_lith(L, F, x₁, fx₁, x₀, fx₀) # [x₀,x₁,…,xₛ₋₁], ...
+    xs, ys = init_lith(L, F, x₁, fx₁, x₀, fx₀, ys₀) # [x₀,x₁,…,xₛ₋₁], ...
     # skip unit consideration here, as won't fit within storage of ys
     state = LithBoonkkampIJzermanState{S,D + 1,R,T}(
         xs[end],    # xₙ
@@ -195,12 +257,13 @@ function update_state(
     end
     @set! xs[end] = xᵢ
 
+    ysᵢ = evalf(F, xᵢ)
     for i in 0:D
         i′ = i + 1
         for j in 1:(S - 1)
             @set! ys[i′][j] = ys[i′][j + 1]
         end
-        yij::T = evalf(F, xᵢ, i′)
+        yij::T = ysᵢ[i′]
         @set! ys[i′][end] = yij
     end
     incfn(l, 1 + D)
@@ -225,6 +288,7 @@ function init_lith(
     fx₁::T,
     x₀::R,
     fx₀::T,
+    ys₀
 ) where {S,Si,Tup,𝑭,P,R,T}
     xs = NTuple{S,R}(ntuple(_ -> one(R), Val(S)))
     yᵢ = NTuple{S,T}(ntuple(_ -> one(T), Val(S)))
@@ -234,7 +298,7 @@ function init_lith(
     x0::R = zero(R)
     if isnan(x₀)
         x0 = _default_secant_step(x₁)
-        fx0::T = evalf(F, x0, 1)
+        fx0::T = only_f(F,x0)
     else
         x0, fx0 = x₀, fx₀
     end
@@ -246,7 +310,7 @@ function init_lith(
 
     for i in 3:S
         xᵢ::R = lmm(Val(i - 1), Val(0), xs, ys) # XXX allocates due to runtime i-1
-        y1i::T = evalf(F, xᵢ, 1)
+        y1i::T = only_f(F,xᵢ)
         @set! xs[i] = xᵢ
         @set! ys[1][i] = y1i
     end
@@ -262,25 +326,26 @@ function init_lith(
     fx₁::T,
     x₀::R,
     fx₀::T,
+    ys₀
 ) where {S,D,Si,Tup,𝑭,P,R,T}
     xs = NTuple{S,R}(ntuple(_ -> one(R), Val(S)))
     yᵢ = NTuple{S,T}(ntuple(_ -> one(T), Val(S)))
     ys = NTuple{D + 1,NTuple{S,T}}(ntuple(_ -> yᵢ, Val(D + 1)))
 
     @set! xs[1] = x₁
-    @set! ys[1][1] = fx₁
-    for i in 1:D
-        yi1::T = evalf(F, x₁, i + 1)
-        @set! ys[i + 1][1] = yi1
+    for i in 1:D+1
+        yi1::T = ys₀[i]
+        @set! ys[i][1] = yi1
     end
 
     # build up to get S of them
     for i in 2:S
         xᵢ::R = lmm(Val(i - 1), Val(D), xs, ys) # XXX allocates! clean up
         @set! xs[i] = xᵢ
-        for j in 0:D
-            yji::T = evalf(F, xᵢ, j + 1)
-            @set! ys[j + 1][i] = yji
+        ysᵢ = evalf(F, xᵢ)
+        for j in 1:(D+1)
+            yji::T = ysᵢ[j]
+            @set! ys[j][i] = yji
         end
     end
 
@@ -323,15 +388,18 @@ struct LithBoonkkampIJzermanBracketState{T,S,R} <: AbstractUnivariateZeroState{T
     fpc::R
 end
 
-function init_state(L::LithBoonkkampIJzermanBracket, F, x₀, x₁, fx₀, fx₁)
-    a, b, fa, fb = x₀, x₁, fx₀, fx₁
+fn_argout(::LithBoonkkampIJzermanBracket) = 2
+
+function init_state(M::LithBoonkkampIJzermanBracket, F::Callable_Function, x)
+    x₀, x₁ = adjust_bracket(x)
+    fx₀,Δfx₀ = F(x₀)
+    fx₁,Δfx₁ = F(x₁)
+    a, b, fa, fb, f′a, f′b = x₀, x₁, fx₀, fx₁, fx₀/Δfx₀, fx₁/Δfx₁
     if abs(fa) < abs(fb)
         a, b, fa, fb = b, a, fb, fa
     end
-
     assert_bracket(fa, fb)
 
-    f′a, f′b = evalf(F, a, 2), evalf(F, b, 2)
     c, fc, f′c = a, fa, f′a
 
     # skip unit consideration here, as won't fit within storage of ys
@@ -409,14 +477,15 @@ function update_state(
 
     # compare to bisection step; extra function evaluation
     d₁ = a + (b - a) * (0.5) #_middle(a, b)
-    f₀, f₁ = evalf(F, d₀, 1), evalf(F, d₁, 1)
+    f₀, Δf₀ = F(d₀)
+    f₁, Δf₁ = F(d₁)
 
     # interpolation outside a,b or bisection better use that
     d::T, fd::S, f′d::S = zero(T), zero(S), zero(S)
     if (abs(f₀) < abs(f₁)) && (min(a, b) < d₀ < max(a, b))
-        d, fd, f′d = d₀, f₀, evalf(F, d₀, 2)# interp
+        d, fd, f′d = d₀, f₀, f₀/Δf₀# interp
     else
-        d, fd, f′d = d₁, f₁, evalf(F, d₁, 2)#  bisection
+        d, fd, f′d = d₁, f₁, f₁/Δf₁#  bisection
     end
 
     # either [a,d] a bracket or [d,b]

--- a/src/Derivative/lith.jl
+++ b/src/Derivative/lith.jl
@@ -139,7 +139,7 @@ function evalf(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{tru
 end
 
 function evalf(F::Callable_Function{S,T,𝑭,P},x) where {N,S<:Val{N},T<:Val{true},𝑭,P}
-    map(f -> f(x,F.p), F.f)
+    fi = map(f -> f(x,F.p), F.f)
     R = typeof(float(first(fi)))
     convert(NTuple{N,R},fi)
 end

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -89,29 +89,72 @@ end
 
 @testset "Lith Boonkkamp IJzerman methods" begin
     x₀, x̃₀, α = 1.0, 1.1, 1.1673039782614187
-    f(x) = x^5 - x - 1
+    f(x,p = 1) = x^5 - x - p
     fp(x) = 5x^4 - 1
     fpp(x) = 20x^3
     fppp(x) = 60x
     fpppp(x) = 60
 
+    function fdf1(x,p = 1)
+        fx = f(x,p)
+        ∂fx = fp(x)
+        return fx,fx/∂fx
+    end
+
+    function fdf2(x,p = 1)
+        fx = f(x,p)
+        ∂fx = fp(x)
+        ∂2fx = fpp(x)
+        return fx,fx/∂fx,∂fx/∂2fx
+    end
+
+    function fdf3(x,p = 1)
+        fx = f(x,p)
+        ∂fx = fp(x)
+        ∂2fx = fpp(x)
+        ∂3fx = fppp(x)
+        return fx,fx/∂fx,∂fx/∂2fx,∂2fx/∂3fx
+    end
+
+    function fdf4(x,p = 1)
+        fx = f(x,p)
+        ∂fx = fp(x)
+        ∂2fx = fpp(x)
+        ∂3fx = fppp(x)
+        ∂4fx = fpppp(x)
+        return fx,fx/∂fx,∂fx/∂2fx,∂2fx/∂3fx,∂3fx/∂4fx
+    end
+
     @test solve(ZeroProblem((f,), x₀), Roots.LithBoonkkampIJzerman(3, 0)) ≈ α
     @test solve(ZeroProblem(f, x₀), Roots.LithBoonkkampIJzerman(3, 0)) ≈ α
     @test solve(ZeroProblem((f,), x₀), Roots.LithBoonkkampIJzerman(4, 0)) ≈ α
     @test solve(ZeroProblem(f, x₀), Roots.LithBoonkkampIJzerman(4, 0)) ≈ α
+    @test solve(ZeroProblem((f,), x₀), Roots.LithBoonkkampIJzerman(3, 0), 1) ≈ α
+    @test solve(ZeroProblem(f, x₀), Roots.LithBoonkkampIJzerman(3, 0), 1) ≈ α
 
     @test solve(ZeroProblem((f, fp), x₀), Roots.LithBoonkkampIJzerman(2, 1)) ≈ α
     @test solve(ZeroProblem((f, fp), x₀), Roots.LithBoonkkampIJzerman(3, 1)) ≈ α
+    @test solve(ZeroProblem(fdf1, x₀), Roots.LithBoonkkampIJzerman(2, 1)) ≈ α
+    @test solve(ZeroProblem(fdf1, x₀), Roots.LithBoonkkampIJzerman(2, 1), 1) ≈ α
 
     @test solve(ZeroProblem((f, fp, fpp), x₀), Roots.LithBoonkkampIJzerman(1, 2)) ≈ α
     @test solve(ZeroProblem((f, fp, fpp), x₀), Roots.LithBoonkkampIJzerman(2, 2)) ≈ α
+    @test solve(ZeroProblem(fdf2, x₀), Roots.LithBoonkkampIJzerman(1, 2)) ≈ α
+    @test solve(ZeroProblem(fdf2, x₀), Roots.LithBoonkkampIJzerman(1, 2), 1) ≈ α
 
     @test solve(ZeroProblem((f, fp, fpp, fppp), x₀), Roots.LithBoonkkampIJzerman(1, 3)) ≈ α
     @test solve(ZeroProblem((f, fp, fpp, fppp), x₀), Roots.LithBoonkkampIJzerman(2, 3)) ≈ α
+    @test solve(ZeroProblem(fdf3, x₀), Roots.LithBoonkkampIJzerman(1, 3)) ≈ α
+    @test solve(ZeroProblem(fdf3, x₀), Roots.LithBoonkkampIJzerman(1, 3), 1) ≈ α
+
+
+    @test solve(ZeroProblem(fdf4, x₀), Roots.LithBoonkkampIJzerman(1, 4)) ≈ α
+    @test solve(ZeroProblem(fdf4, x₀), Roots.LithBoonkkampIJzerman(1, 4), 1) ≈ α
 
     @test solve(
         ZeroProblem((f, fp, fpp, fppp, fpppp), x₀),
         Roots.LithBoonkkampIJzerman(1, 4),
+        
     ) ≈ α
     @test solve(
         ZeroProblem((f, fp, fpp, fppp, fpppp), x̃₀),
@@ -120,4 +163,8 @@ end
 
     # bracketing
     @test solve(ZeroProblem((f, fp), (1, 2)), Roots.LithBoonkkampIJzermanBracket()) ≈ α
+    @test solve(ZeroProblem(fdf1, (1, 2)), Roots.LithBoonkkampIJzermanBracket()) ≈ α
+    @test solve(ZeroProblem(fdf1, (1, 2)), Roots.LithBoonkkampIJzermanBracket(),1) ≈ α
+
+
 end


### PR DESCRIPTION
solves #377
on the specifics:
i removed `evalf(F,x,i)` in favor of just `evalf(F,x)`. i checked that the same amount of calls, but a review would help. i noted some allocations, (`lmm(Val(i),...)` in a loop) but haven't fixed those. 

on the preferences, i used in some parts `only_f(F,x) = evalf(F,x,1)`, but those only appear in methods of D = 0. the consecuence for that is that you could pass a higher order tuple function into a Lith method and it could work, but those cases could be replaced by just using `F(x)` instead.