### PR TITLE
Change p′ to p in `find_zero`'s docstring

### DIFF
--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -1,6 +1,6 @@
 """
 
-    find_zero(f, x0, M, [N::AbstractBracketingMethod], [p′=nothing]; kwargs...)
+    find_zero(f, x0, M, [N::AbstractBracketingMethod], [p=nothing]; kwargs...)
 
 Interface to one of several methods for finding zeros of a univariate function, e.g. solving ``f(x)=0``.
 


### PR DESCRIPTION
The rest of the text seems to refer to `p` as the collection of parameters, but the function signature uses `p′`