### PR TITLE
fix issue with measurements; close #453

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -32,6 +32,7 @@ CommonSolve = "0.1, 0.2"
 ForwardDiff = "0.10"
 IntervalRootFinding = "0.5"
 JSON = "0.21"
+Measurements = "2.11"
 Polynomials = "1,2,3,4"
 Printf = "<0.0.1, 1"
 SpecialFunctions = "1,2"
@@ -50,6 +51,7 @@ ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -60,4 +62,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "ChainRulesTestUtils", "JSON", "SpecialFunctions", "Statistics", "Test", "BenchmarkTools", "ForwardDiff", "Polynomials", "Unitful", "Zygote"]
+test = ["Aqua", "ChainRulesTestUtils", "JSON", "SpecialFunctions", "Statistics", "Test", "BenchmarkTools", "ForwardDiff", "Measurements", "Polynomials", "Unitful", "Zygote"]

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -108,6 +108,7 @@ function update_state(
     options,
     l=NullTracks(),
 ) where {T,S}
+
     atol, rtol = options.xabstol, options.xreltol
     μ, λ = oftype(rtol, 0.5), oftype(rtol, 0.7)
     tols = (; λ=λ, atol=atol, rtol=rtol)
@@ -145,7 +146,10 @@ function update_state(
 
     ā, b̄, d, fā, fb̄, fd = bracket(a, b, x, fa, fb, fx)
 
-    if iszero(fx) || (b̄ - ā) <= tolₑ(ā, b̄, fā, fb̄, atol, rtol)
+
+    if ((b̄ - ā) <= tolₑ(ā, b̄, fā, fb̄, atol, rtol) ||
+        iszero(fx) ||      # exact zero
+        !isbracket(fā,fb̄)) # catch non bracket?, issue #453
         @reset o.xn0 = ā
         @reset o.xn1 = b̄
         @reset o.fxn0 = fā

--- a/test/test_composable.jl
+++ b/test/test_composable.jl
@@ -7,6 +7,7 @@ using Test
 using Unitful
 using Polynomials
 using ForwardDiff
+using Measurements
 
 @testset "Test composability with other packages" begin
     orders = [
@@ -82,4 +83,18 @@ using ForwardDiff
     α = find_zero(D(h), (0, 1)) # find lowest point on loop
     @test h(α) ≤ h(α + 0.1)
     @test h(α) ≤ h(α - 0.1)
+
+
+    # Measurements # issue #453
+    @testset "Measurements.jl" begin
+        a = measurement(1.0 , 0.1)
+        b = measurement(-3.0 , 0.1)
+        c = measurement(-10.0, 0.1)
+        f(x) = a*x^2 + b*x + c
+        x₀ = (measurement(-3.0, 0.1), measurement(0.0, 0.1))
+        for M ∈ (A42(), AlefeldPotraShi(), Bisection())
+            @test find_zero(f,x₀, M) ≈ -2.0
+        end
+        @test find_zero(f, measurement(0.0, 0.1)) ≈ -2.0
+    end
 end


### PR DESCRIPTION
When using with `Measurements`, the Alefeld-Potra-Shi algorithms can lose their bracket, causing the algorithm to fail. This catches that behaviour and moves to check convergence.