### PR TITLE
bug fix

### DIFF
--- a/src/Bracketing/brent.jl
+++ b/src/Bracketing/brent.jl
@@ -60,7 +60,7 @@ function update_state(
     tol = max(options.xabstol, max(abs(b), abs(c), abs(d)) * options.xreltol)
     if !(u < s < v) ||
        (mflag && abs(s - b) >= abs(b - c) / 2) ||
-       (!mflag && abs(s - b) >= abs(b - c) / 2) ||
+       (!mflag && abs(s - b) >= abs(c - d) / 2) ||
        (mflag && abs(b - c) <= tol) ||
        (!mflag && abs(c - d) <= tol)
         s = _middle(a, b)


### PR DESCRIPTION
corrected small typo in the Brent's method.

According to the model, the second condition is

(mflag is cleared and |s-b| >= |c-d|/2)

not

(mflag is cleared and |s-b| >= |b-c|/2)

The first iteration would be the same but after it might vary.