### PR TITLE
fix(Unitful): `find_zero` on `<:Quantity` interval chooses `Bisection` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
 SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 RootsChainRulesCoreExt = "ChainRulesCore"
@@ -21,6 +22,7 @@ RootsForwardDiffExt = "ForwardDiff"
 RootsIntervalRootFindingExt = "IntervalRootFinding"
 RootsSymPyExt = "SymPy"
 RootsSymPyPythonCallExt = "SymPyPythonCall"
+RootsUnitfulExt = "Unitful"
 
 [compat]
 Accessors = "0.1.33"

--- a/ext/RootsUnitfulExt.jl
+++ b/ext/RootsUnitfulExt.jl
@@ -1,0 +1,10 @@
+module RootsUnitfulExt
+using Unitful
+using Roots
+
+function Roots.find_zero_default_method(x0::Tuple{<:Quantity,<:Quantity})
+    T = eltype(ustrip.(float.(Roots._extrema(x0))))
+    T <: Union{Float16,Float32,Float64} ? Roots.Bisection() : Roots.A42()
+end
+
+end # module

--- a/test/test_extensions.jl
+++ b/test/test_extensions.jl
@@ -70,6 +70,13 @@ using ForwardDiff
     end
 end
 
+using Unitful
+@testset "Unitful" begin
+    f = x -> -exp(ustrip(x)) + 3
+    @test find_zero(f, (0u"nm", Inf * 1u"nm")) ==
+          find_zero(x -> f(x * 1u"nm"), (0, Inf)) * 1u"nm"
+end
+
 #=
 using IntervalRootFinding
 @testset "IntervalRootFinding" begin


### PR DESCRIPTION
Previously: 
```julia 
julia> f = x -> -exp(ustrip(x)) + 3
#17 (generic function with 1 method)

julia> find_zero(f, (0.0u"nm", Inf*1u"nm"))
ERROR: Roots.ConvergenceFailed("Algorithm failed to converge")
Stacktrace:
 [1] find_zero(f::Function, x0::Tuple{Quantity{Float64, 𝐋, Unitful.FreeUnits{(nm,), 𝐋, nothing}}, Quantity{Float64, 𝐋, Unitful.FreeUnits{(nm,), 𝐋, nothing}}}, M::A42, p′::Nothing; p::Nothing, verbose::Bool, tracks::Roots.NullTracks, kwargs::@Kwargs{})
   @ Roots ~/.julia/packages/Roots/ohGnS/src/find_zero.jl:229
 [2] find_zero (repeats 2 times)
   @ ~/.julia/packages/Roots/ohGnS/src/find_zero.jl:210 [inlined]
 [3] find_zero(f::Function, x0::Tuple{Quantity{Float64, 𝐋, Unitful.FreeUnits{(nm,), 𝐋, nothing}}, Quantity{Float64, 𝐋, Unitful.FreeUnits{(nm,), 𝐋, nothing}}})
   @ Roots ~/.julia/packages/Roots/ohGnS/src/find_zero.jl:243
 [4] top-level scope
   @ REPL[18]:1

julia> f_nounit = x -> -exp(x) + 3
#20 (generic function with 1 method)

julia> find_zero(f_nounit, (0.0, Inf))
1.0986122886681098
```

Now: 
```julia 
julia> f = x -> -exp(ustrip(x)) + 3
#17 (generic function with 1 method)

julia> find_zero(f, (0.0u"nm", Inf*1u"nm"))
1.0986122886681098 nm

julia> find_zero(x -> f(x * 1u"nm"), (0.0, Inf)) * u"nm"
1.0986122886681098 nm
```

- A method for choosing the same default as with dimensionless interval was added for the `Quantity` interval tuple.
- A test with the broken method has been added
