### PR TITLE
add warning for certain tolerance specification; Close #479

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "2.2.10"
+version = "2.2.11"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -97,7 +97,7 @@ function init_options(
         @warn "This bracketing method only has tolerances `xatol` and `xrtol`. Any settings for `atol` or `rtol` are ignored."
     end
 
-    Δₐ = get(d, :xatol, get(d, :xabstol, defs[1]))
+    δₐ = get(d, :xatol, get(d, :xabstol, defs[1]))
     δᵣ = get(d, :xrtol, get(d, :xreltol, defs[2]))
     maxiters = get(d, :maxiters, get(d, :maxevals, get(d, :maxsteps, defs[5])))
     strict = get(d, :strict, defs[6])

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -92,7 +92,12 @@ function init_options(
 ) where {T,S}
     d = kwargs
     defs = default_tolerances(M, T, S)
-    δₐ = get(d, :xatol, get(d, :xabstol, defs[1]))
+    # warn if atol or rtol are passed in
+    if haskey(d, :atol) || haskey(d, :rtol)
+        @warn "This bracketing method only has tolerances `xatol` and `xrtol`. Any settions for `atol` or `rtol` are ignored."
+    end
+
+    Δₐ = get(d, :xatol, get(d, :xabstol, defs[1]))
     δᵣ = get(d, :xrtol, get(d, :xreltol, defs[2]))
     maxiters = get(d, :maxiters, get(d, :maxevals, get(d, :maxsteps, defs[5])))
     strict = get(d, :strict, defs[6])

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -94,7 +94,7 @@ function init_options(
     defs = default_tolerances(M, T, S)
     # warn if atol or rtol are passed in
     if haskey(d, :atol) || haskey(d, :rtol)
-        @warn "This bracketing method only has tolerances `xatol` and `xrtol`. Any settions for `atol` or `rtol` are ignored."
+        @warn "This bracketing method only has tolerances `xatol` and `xrtol`. Any settings for `atol` or `rtol` are ignored."
     end
 
     Δₐ = get(d, :xatol, get(d, :xabstol, defs[1]))


### PR DESCRIPTION
This adds a warning when `atol` or `rtol` are specified to Alefeld Potra Shi methods.

Still need to review if this can be done where other options are not considered.