### PR TITLE
Modab 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "2.2.12"
+version = "2.2.13"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Bracketing/modAB.jl
+++ b/src/Bracketing/modAB.jl
@@ -109,6 +109,8 @@ function update_state(
         x3 = x1/2 + x2/2 #__middle(x1, x2)
         y3::S = F(x3)
         incfn(l)
+
+        # continue with bisection?
         ym = y1/2 + y2/2
         if abs(ym - y3) < κ * (abs(ym) + abs(y3))
             bisection = false
@@ -130,7 +132,35 @@ function update_state(
         return (o, true)
     end
 
+    if sign(y1) == sign(y3)
+        if side == :right
+            m = 1 - y3 / y1
+            if m <= 0
+                y2 /= 2
+            else
+                y2 *= m
+            end
+        elseif !bisection
+            side = :right
+        end
+        x1 = x3
+        y1 = y3
+    else
+        if side == :left
+            m = 1 - y3 / y2
+            if m <= 0
+                y1 /= 2
+            else
+                y1 *= m
+            end
+        elseif !bisection
+            side = :left
+        end
+        x2 = x3
+        y2 = y3
+    end
 
+    #=
     if side == :left
         m = 1 - y3/y1
         y2 = m ≤ 0 ? y2/2 : y2*m
@@ -146,12 +176,20 @@ function update_state(
         !bisection && (side = :right)
         x2, y2 = x3, y3
     end
+    =#
 
+    #=
     if rem(cnt, N) == 0
         bisection == true # restart
         side = :nothing
     end
+    =#
 
+    if cnt > N
+        N = 2N
+        bisection=true
+        side = :nothing
+    end
 
     @reset o.xn0 = x1
     @reset o.xn1 = x2

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -313,7 +313,7 @@ function assess_convergence(
     a, b, fa, fb = state.xn0, state.xn1, state.fxn0, state.fxn1
     u, fu = choose_smallest(a, b, fa, fb)
     δₐ, δᵣ = options.xabstol, options.xreltol
-    δₓ = max(δₐ, 2 * abs(u) * δᵣ) # needs non-zero δₐ to stop near 0
+    δₓ = max(δₐ, 2 * (abs(u) * δᵣ)) # needs non-zero δₐ to stop near 0
     abs(b - a) ≤ δₓ && return (:x_converged, true)
 
     return (:not_converged, false)

--- a/test/benchmark-bracketing-methods.jl
+++ b/test/benchmark-bracketing-methods.jl
@@ -253,8 +253,8 @@ const all_problems = vcat(problems1, problems2, problems3)
 
 const solvers = [
     ("bisect", bisect_solver),
-#    (" brent", brent_solver),
-#    ("ridder", ridder_solver),
+    (" brent", brent_solver),
+    ("ridder", ridder_solver),
     ("   A42", a42_solver),
     ("   ITP", itp_solver),
     (" ModAB", modab_solve),
@@ -336,10 +336,10 @@ function run_benchmark(;verbose = false)
 end
 
 @testset "count bracketing steps" begin
-#    nms, cnts = run_benchmark()
+    nms, cnts = run_benchmark()
 
     # bisect ≥ A42 ≥ ITP ≥ ModAB
-#    @test cnts[1] ≥ cnts[4] ≥ cnts[5] ≥ cnts[6]
+    @test cnts[1] ≥ cnts[4] ≥ cnts[5] ≥ cnts[6]
 end
 
 end

--- a/test/benchmark-bracketing-methods.jl
+++ b/test/benchmark-bracketing-methods.jl
@@ -253,8 +253,8 @@ const all_problems = vcat(problems1, problems2, problems3)
 
 const solvers = [
     ("bisect", bisect_solver),
-    (" brent", brent_solver),
-    ("ridder", ridder_solver),
+#    (" brent", brent_solver),
+#    ("ridder", ridder_solver),
     ("   A42", a42_solver),
     ("   ITP", itp_solver),
     (" ModAB", modab_solve),
@@ -336,10 +336,10 @@ function run_benchmark(;verbose = false)
 end
 
 @testset "count bracketing steps" begin
-    nms, cnts = run_benchmark()
+#    nms, cnts = run_benchmark()
 
     # bisect ≥ A42 ≥ ITP ≥ ModAB
-    @test cnts[1] ≥ cnts[4] ≥ cnts[5] ≥ cnts[6]
+#    @test cnts[1] ≥ cnts[4] ≥ cnts[5] ≥ cnts[6]
 end
 
 end


### PR DESCRIPTION
This PR follows up with a refinement to `ModAB` allowing infinite intervals.

* uses `__middle` instead of the more direct `x1/2 + x2/2` which imposes an upperbound on the number of bisection steps but does mean some problems can take a few more steps. (The benchmark illustrates this)
* fixes a bug in assess convergence causing incorrect termination