### PR TITLE
deprecate verbose

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "2.2.14"
+version = "2.3.0"
 
 
 [deps]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -325,7 +325,9 @@ fzeros
 
 ## Tracking iterations
 
-It is possible to add the keyword argument `verbose=true`  when calling the `find_zero` function to get detailed information about the solution and data from each iteration. To save this data a `Tracks`object may be passed in to `tracks`.
+To save this data a `Roots.Tracks`object may be passed in to `tracks` and displayed later.
+
+Passing the keyword argument `verbose=true`  is now deprecated when calling the `find_zero` function to get detailed information about the solution and data from each iteration.
 
 ----
 

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -318,8 +318,9 @@ longer super-linear. This is the case here, where `Order2` uses $51$
 function calls, `Order8` uses $42$, and `Order0` takes  $80$. The `Roots.Order2B` method is useful
 when a multiplicity is expected; on this problem it takes ``17`` function calls.
 
-To investigate an algorithm and its convergence, the argument
-`verbose=true` may be specified. A `Roots.Tracks` object can be used to store the intermediate values.
+A `Roots.Tracks` object can be used to store the intermediate values and can be displayed.
+
+It is now deprecated to use the `verbose=true` argument to investigate an algorithm and its convergence.
 
 
 For some functions, adjusting the default tolerances may be necessary

--- a/src/find_zero.jl
+++ b/src/find_zero.jl
@@ -18,7 +18,7 @@ Interface to one of several methods for finding zeros of a univariate function, 
 * `xatol`, `xrtol`: absolute and relative tolerance to decide if `xₙ₊₁ ≈ xₙ`
 * `atol`, `rtol`: absolute and relative tolerance to decide if `f(xₙ) ≈ 0`
 * `maxiters`: specify the maximum number of iterations the algorithm can take.
-* `verbose::Bool`: specifies if details about algorithm should be shown
+* `verbose::Bool`: specifies if details about algorithm should be shown [Deprecated; use `tracks`]
 * `tracks`: allows specification of `Tracks` objects
 
 # Extended help
@@ -199,7 +199,8 @@ ERROR: Roots.ConvergenceFailed("Algorithm failed to converge")
 
 # Tracing
 
-Passing `verbose=true` will show details on the steps of the algorithm.
+Passing `verbose=true` will show details on the steps of the algorithm. [This is deprecated, use `tracks`.]
+
 The `tracks` argument allows
 the passing of a [`Roots.Tracks`](@ref) object to record the values of `x` and `f(x)` used in
 the algorithm.
@@ -217,6 +218,7 @@ function find_zero(
     tracks::AbstractTracks=NullTracks(),
     kwargs...,
 )
+
     xstar = solve(
         ZeroProblem(f, x0),
         M,
@@ -295,6 +297,7 @@ function init(
     tracks=NullTracks(),
     kwargs...,
 )
+
     F = Callable_Function(M, 𝑭𝑿.F, something(p′, p, missing))
     state = init_state(M, F, 𝑭𝑿.x₀)
     options = init_options(M, state; kwargs...)
@@ -354,7 +357,7 @@ The latter calls the following, which can be useful independently:
 Returns `NaN`, not an error like `find_zero`, when the problem can not
 be solved. Tested for zero allocations.
 
-
+The `verbose` keyword is deprecated; pass a `Tracks` object to trace the algorithm.
 
 ## Examples:
 
@@ -449,6 +452,14 @@ julia> order0(sin, 3)
 function solve!(P::ZeroProblemIterator; verbose=false)
     M, F, state, options, l = P.M, P.F, P.state, P.options, P.logger
 
+    if verbose !== false
+        Base.depwarn(
+            "The `verbose` keyword is deprecated. Pass a `tracks=Roots.Tracks()` object to the solver to see a trace.",
+            :solve!
+        )
+    end
+
+
     val, stopped = :not_converged, false
     ctr = 1
     log_step(l, M, state; init=true)
@@ -494,6 +505,7 @@ function solve(
     verbose=false,
     kwargs...,
 )
+
     Z = init(𝑭𝑿, M, p; verbose=verbose, kwargs...)
     solve!(Z; verbose=verbose)
 end

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -44,6 +44,8 @@ implementation details may change without notice.) The methods
 `empty!`, to reset the `Tracks` object; `get`, to get the tracks;
 `last`, to get the value converted to, may be of interest.
 
+[The following is now deprecated.]
+
 If you only want to print the information, but you don't need it later, this can conveniently be
 done by passing `verbose=true` to the root-finding function. This will not
 effect the return value, which will still be the root of the function.


### PR DESCRIPTION
PR #503 removes the `verbose=true` argument from `find_zero`, as the code path had issues with `JET.@report_opt`.  This PR provides for the deprecation of the argument.