### PR TITLE
add NonStrictBracketing type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Roots"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "3.0.4"
+version = "3.0.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Bracketing/alefeld_potra_shi.jl
+++ b/src/Bracketing/alefeld_potra_shi.jl
@@ -21,7 +21,7 @@ This implementation deviates slightly from the printed algorithm, as it may use 
     These algorithms do not check the size of `f` for convergence, so the `atol` or `rtol` are not utilized.
 """
 =#
-abstract type AbstractAlefeldPotraShi <: AbstractBracketingMethod end
+abstract type AbstractAlefeldPotraShi <: AbstractNonStrictBracketingMethod end
 
 initial_fncalls(::AbstractAlefeldPotraShi) = 3 # worst case assuming fx₀, fx₁,fc must be computed
 

--- a/src/Bracketing/bracketing.jl
+++ b/src/Bracketing/bracketing.jl
@@ -54,6 +54,20 @@ function default_tolerances(
     (xatol, xrtol, atol, rtol, maxevals, strict)
 end
 
+# Non strict has check on non convergence with relaxed tolerances
+function default_tolerances(
+    ::AbstractNonStrictBracketingMethod,
+    ::AbstractUnivariateZeroState{T,S},
+) where {T,S}
+    xatol = eps(real(T))^3 * oneunit(real(T))
+    xrtol = eps(real(T))  # unitless
+    atol = zero(oneunit(real(S)))
+    rtol = zero(one(real(S)))
+    maxevals = 60
+    strict = false
+    (xatol, xrtol, atol, rtol, maxevals, strict)
+end
+
 ## --------------------------------------------------
 
 const bracketing_error = """The interval [a,b] is not a bracketing interval.

--- a/src/Bracketing/brent.jl
+++ b/src/Bracketing/brent.jl
@@ -7,7 +7,7 @@ This method uses a choice of inverse quadratic interpolation or a secant
 step, falling back on bisection if necessary.
 
 """
-struct Brent <: AbstractBracketingMethod end
+struct Brent <: AbstractNonStrictBracketingMethod end
 
 struct BrentState{T,S} <: AbstractUnivariateZeroState{T,S}
     xn1::T

--- a/src/Bracketing/chandrapatlu.jl
+++ b/src/Bracketing/chandrapatlu.jl
@@ -10,7 +10,7 @@ Chandrapatla's algorithm chooses between an inverse quadratic step or a bisectio
 
 
 """
-struct Chandrapatla <: AbstractBracketingMethod end
+struct Chandrapatla <: AbstractNonStrictBracketingMethod end
 
 struct ChandrapatlaState{T,S} <: AbstractUnivariateZeroState{T,S}
     xn1::T

--- a/src/Bracketing/itp.jl
+++ b/src/Bracketing/itp.jl
@@ -21,7 +21,7 @@ Suggested on
 by `@TheLateKronos`, who supplied the original version of the code.
 
 """
-struct ITP{T,S} <: AbstractBracketingMethod
+struct ITP{T,S} <: AbstractNonStrictBracketingMethod
     κ₁::T
     κ₂::S
     n₀::Int

--- a/src/Bracketing/regula_falsi.jl
+++ b/src/Bracketing/regula_falsi.jl
@@ -98,7 +98,9 @@ function update_state(
     f̂xₙ₋₁::S, f̂xₙ::S = o.fxn0, o.fxn1
 
     c::T = (xₙ₋₁ * f̂xₙ - xₙ * f̂xₙ₋₁) / (f̂xₙ - f̂xₙ₋₁)
-    if (c == xₙ₋₁ || c == xₙ) # try midpoint o/w this is stuck
+
+    ϵ = maximum(abs, (xₙ, xₙ₋₁)) * √eps(T)  # some engineering to avoid short moves
+    if abs(c - xₙ) ≤ ϵ || abs(c - xₙ₋₁) ≤ ϵ
         c = xₙ₋₁/2 + xₙ/2
     end
 

--- a/src/Bracketing/ridders.jl
+++ b/src/Bracketing/ridders.jl
@@ -23,7 +23,7 @@ true
 `f=F', g=F''/2, h=F'''/6`, suggesting converence at rate `≈ 1.839...`. It uses two function evaluations per step, so
  its order of convergence is `≈ 1.225...`.
 """
-struct Ridders <: AbstractBracketingMethod end
+struct Ridders <: AbstractNonStrictBracketingMethod end
 
 function update_state(
     M::Ridders,

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -5,6 +5,7 @@ Base.broadcastable(method::AbstractUnivariateZeroMethod) = Ref(method)
 abstract type AbstractBracketingMethod <: AbstractUnivariateZeroMethod end
 abstract type AbstractBisectionMethod <: AbstractBracketingMethod end
 abstract type AbstractRegulaFalsiMethod <: AbstractBracketingMethod end
+abstract type AbstractNonStrictBracketingMethod <: AbstractBracketingMethod end
 
 abstract type AbstractNonBracketingMethod <: AbstractUnivariateZeroMethod end
 abstract type AbstractSecantMethod <: AbstractNonBracketingMethod end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -348,48 +348,50 @@ function decide_convergence(
     val,
 ) where {T, S}
 
-    a, b = xs = state.xn0, state.xn1
-    fa, fb = fxs = state.fxn0, state.fxn1
+    b, a = xs = state.xn1, state.xn0
+    fb, fa = fxs = state.fxn1, state.fxn0
+    m,i = findmin(abs, fxs)
+    α = xs[i]
 
-    if val == :not_converged
+    if val == :exact_zero
+        return α
+    elseif val == :x_converged
+        # when exact closeness is *possible*
+        # get as close as possible with one extra function call
+        u, v, fu, fv = a < b ? (a, b, fa, fb) : (b, a, fb, fa)
+        u₊ = nextfloat(float(u))
+        u₊₊ = nextfloat(u₊)
+        if v == u₊₊
+            fu₊ = first(F(u₊))
+            m, i = findmin(abs, (fu, fu₊, fv))
+            return (u, u₊, v)[i]
+        else
+            return α
+        end
+    elseif val == :not_converged
         if !options.strict
             # check relaxed convergence on Δx, f(x)
             # Δ ≤ 2^8 * max(δ + |x|⋅ϵ)
             # |f(x)| ≤ 16*min(16δ + |x|⋅ϵ) -- 0 by default
-            m,i = findmin(abs, fxs)
             mx = maximum(abs, xs)
-
 
             Δ = abs(xs[1] - xs[2])
             ϵ = 256 * max(options.xabstol, mx * sqrt(options.xreltol))
-            _unitless(Δ) ≤ _unitless(ϵ) && return xs[i]
+            _unitless(Δ) ≤ _unitless(ϵ) && return α
 
             atol = max(eps(oneunit(real(S))), options.abstol)
             rtol = max(eps(one(real(S))), options.xreltol)
             δ = 16 * min(16*atol, maximum(abs, xs) * rtol)
-            _unitless(m) ≤ _unitless(δ)  && return xs[i]
+            _unitless(m) ≤ _unitless(δ)  && return α
         end
-
         return nan(T) * state.xn1
     end
 
-
-    iszero(fa) && return a
-    iszero(fb) && return b
     isnan(fa) && return a
     isnan(fb) && return b
+    iszero(fa) && return a
+    iszero(fb) && return b
 
-    # get as close as possible with one extra function call
-    # when exact closeness is possible
-    a₊₊ = nextfloat(nextfloat(float(a)))
-    if b == a₊₊
-        c = nextfloat(float(a))
-        fc = first(F(c))
-        m = minimum(abs, (fa, fb, fc))
-        abs(fc) == m && return c
-        abs(fa) == m && return a
-        return b
-    end
+    return α
 
-    return (abs(fa) < abs(fb)) ? a : b
 end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -348,41 +348,31 @@ function decide_convergence(
     val,
 ) where {T, S}
 
+    a, b = xs = state.xn0, state.xn1
+    fa, fb = fxs = state.fxn0, state.fxn1
+
     if val == :not_converged
-        # check relaxed convergence on Δx, f(x)
+        if !options.strict
+            # check relaxed convergence on Δx, f(x)
+            # Δ ≤ 2^8 * max(δ + |x|⋅ϵ)
+            # |f(x)| ≤ 16*min(16δ + |x|⋅ϵ) -- 0 by default
+            m,i = findmin(abs, fxs)
+            mx = maximum(abs, xs)
 
-        xs = (state.xn0, state.xn1)
-        fxs = (state.fxn0, state.fxn1)
-        mx = maximum(abs, xs)
-        m,i = findmin(abs, fxs)
 
-        Δ = abs(xs[1] - xs[2])
-        ϵ = 256 * max(options.xabstol, mx * sqrt(options.xreltol))
-        Δ ≤ ϵ && return xs[i]
+            Δ = abs(xs[1] - xs[2])
+            ϵ = 256 * max(options.xabstol, mx * sqrt(options.xreltol))
+            _unitless(Δ) ≤ _unitless(ϵ) && return xs[i]
 
-        atol = max(options.abstol, eps(T))
-        rtol = max(options.reltol, eps(T))
-        δ = 16 * min(16*eps(T), eps(maximum(abs, xs))) # relative tolerance based on x
-        Real(m/oneunit(m)) <= δ  && return xs[i]
-
-        # XXX there should be an error thrown,
-        # but will relaix if https://github.com/lrnv/Copulas.jl/issues/375 isn't resolved
-        #=
-        msg = """
-            xs = $xs, Δ = $(abs(xs[1] - xs[2]))
-            fxs = $fxs
-            xopts = $(options.xreltol), $(options.xabstol)
-            fopts = $(options.reltol), $(options.abstol)
-            strict = $(options.strict)
-        """
-        error(msg)
-        =#
+            atol = max(eps(oneunit(real(S))), options.abstol)
+            rtol = max(eps(one(real(S))), options.xreltol)
+            δ = 16 * min(16*atol, maximum(abs, xs) * rtol)
+            _unitless(m) ≤ _unitless(δ)  && return xs[i]
+        end
 
         return nan(T) * state.xn1
     end
 
-    a, b = state.xn0, state.xn1
-    fa, fb = state.fxn0, state.fxn1
 
     iszero(fa) && return a
     iszero(fb) && return b

--- a/test/test_bracketing.jl
+++ b/test/test_bracketing.jl
@@ -309,7 +309,7 @@ end
     residuals = [result.maxresidual for result in results]
     cnts = [result.evalcount for result in results]
 
-    @test maximum(failures) <= 10
+    @test maximum(failures) <= 0
     @test maximum(residuals) <= 5e-13
     @test avg(cnts) <= 4700
 

--- a/test/test_bracketing.jl
+++ b/test/test_bracketing.jl
@@ -279,71 +279,37 @@ end
 
 @testset "bracketing methods" begin
 
-    ## Test for failures, ideally all of these would be 0
-    ## test for residual, ideally small
-    ## test for evaluation counts, ideally not so low for these problems
-
-    ## exact_bracket
-    Ms = [
+    Ms = (
         Roots.A42(),
         Roots.AlefeldPotraShi(),
         Roots.Chandrapatla(),
         Roots.Bisection(),
         Roots.ModAB(),
-    ]
+        Roots.Brent(),
+        Roots.Ridders(),
+        Roots.ITP(),
+        [Roots.FalsePosition(i) for i in 1:12]...,
+        [Roots.RegulaFalsi(m) for m ∈ (:Illinois, :Pegasus, :AndersonBjork, :Ford3, :Ford4)]...
+    )
+
+    ## Test for failures, ideally all of these would be 0
+    ## test for residual, ideally small
+    ## test for evaluation counts, ideally not so low for these problems
     results = [run_tests((f, b) -> find_zero(f, b, M), name="$M") for M in Ms]
     failures = [length(result.failures) for result in results]
     residuals = [result.maxresidual for result in results]
     cnts = [result.evalcount for result in results]
 
     @test maximum(failures) == 0
-    @test maximum(residuals) <= 5e-13
-    @test avg(cnts) <= 4700
-
-    Ms = [Roots.Brent(),
-          Roots.Ridders(),
-          Roots.ITP()
-          ]
-    results = [run_tests((f, b) -> find_zero(f, b, M), name="$M") for M in Ms]
-    failures = [length(result.failures) for result in results]
-    residuals = [result.maxresidual for result in results]
-    cnts = [result.evalcount for result in results]
-
-    @test maximum(failures) <= 0
-    @test maximum(residuals) <= 5e-13
-    @test avg(cnts) <= 4700
-
-    ## False position has larger residuals
-    ## Fn #13 fails on numbers 2 and 4 until maxsteps is increased; 100 works
-    Ms = [Roots.FalsePosition(i) for i in 1:12]
-    results = [run_tests((f, b) -> find_zero(f, b, M), name="$M") for M in Ms]
-    failures =  [length(result.failures) for result in results]
-    residuals = [result.maxresidual for result in results]
-    cnts = [result.evalcount for result in results]
-
-    @test maximum(failures) == 0
-    @test maximum(residuals) <= 1e-13
-    @test avg(cnts) <= 4000
+    @test maximum(residuals) <= 5e-14
+    @test avg(cnts) <= 5000
 
 
-
-
-    ## issue 412 check for bracket
+    ## issue 412 check for bracket in bracketing methods
     for M in Ms
         @test_throws ArgumentError find_zero(x -> x - 1, (-3, 0), M)
         @test_throws ArgumentError find_zero(x -> 1 + x^2, (10, 20), M)
     end
-
-    ## SFRF
-    Ms = [Roots.RegulaFalsi(m) for m ∈ (:Illinois, :Pegasus, :AndersonBjork, :Ford3, :Ford4)]
-    results = [run_tests((f, b) -> find_zero(f, b, M), name="$M") for M in Ms]
-    failures =  [length(result.failures) for result in results]
-    residuals = [result.maxresidual for result in results]
-    cnts = [result.evalcount for result in results]
-
-    @test maximum(failures) <= 10
-    @test maximum(residuals) <= 1e-14
-    @test avg(cnts) <= 5000
 
 
 end
@@ -390,8 +356,8 @@ end
         for M in Ms
             g = Cnt(fn_)
             x0_ = find_zero(g, ab, M)
-            @test abs(fn_(x0_)) <= 1e-15
-            @test g.cnt <= 50
+            @test abs(fn_(x0_)) <= 1e-14
+            @test g.cnt <= 60
         end
     end
 end
@@ -413,7 +379,7 @@ end
         @test find_zero(f, (-1, 1), M, p=eps()) ≈ eps() atol = 2eps()
     end
 
-    @test iszero(@inferred(find_zero(f, (-1, 1), Roots.Bisection())))
+    @test iszero(@inferred(find_zero(f, (-1, 1), Roots.Bisection()))) # too fiddly to get zero, might get eps(0.0)
     # XXX changes with relaxed tolerance (adding non-zero xatol)
     #@test_throws Roots.ConvergenceFailed find_zero(f, (-1, 1), Roots.A42())
     #@test_throws Roots.ConvergenceFailed find_zero(f, (-1, 1), Roots.AlefeldPotraShi())


### PR DESCRIPTION
* Add `AbstractNonStrictBracketingMethod` which does additional relaxed convergence tests in `decide_convergence`. Apply to `Brent`, `ITP`, `Ridders`, AlefeldPotraShi types.


* Clean up code in decide_convergence for bracketing methods including nonstrict ones

* In RegulaFalsi, more aggressively use a bisection step if proposed point is too close to existing bracketing points.

* shorten test_bracket tests, as now no bracket tests are failures
