### PR TITLE
Deprecate fzero

### DIFF
--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -82,7 +82,7 @@ include("Derivative/lith.jl")
 
 include("find_zeros.jl")
 include("simple.jl")
-include("alternative_interfaces.jl")
+include("deprecated/alternative_interfaces.jl")
 
 if !isdefined(Base, :get_extension)
     include("../ext/RootsChainRulesCoreExt.jl")

--- a/src/deprecated/alternative_interfaces.jl
+++ b/src/deprecated/alternative_interfaces.jl
@@ -83,7 +83,7 @@ Keyword arguments are passed to `find_zero` using the `Roots.QuadraticInverse()`
 """
 =#
 function quadratic_inverse(f, fp, fpp, x0; kwargs...)
-    Base.depwarn("`quadratic_inverse(f, fp, fpp,  x0)` is deprecated; use `find_zero((f,fp, fpp), x0, Roots.Quadratic_Inverse())` instead.", :quadratic_inverse)
+    Base.depwarn("`quadratic_inverse(f, fp, fpp,  x0)` is deprecated; use `find_zero((f,fp, fpp), x0, Roots.QuadraticInverse())` instead.", :quadratic_inverse)
 
     find_zero((f, fp, fpp), x0, QuadraticInverse(); kwargs...)
 end

--- a/src/deprecated/alternative_interfaces.jl
+++ b/src/deprecated/alternative_interfaces.jl
@@ -23,7 +23,10 @@ Keyword arguments are passed to `find_zero` using the `Roots.Newton()` method.
 See also `Roots.newton((f,fp), x0)` and `Roots.newton(fΔf, x0)` for simpler implementations.
 
 """
-newton(f, fp, x0; kwargs...) = find_zero((f, fp), x0, Newton(); kwargs...)
+function newton(f, fp, x0; kwargs...)
+    Base.depwarn("`newton(f, fp, x0)` is deprecated; use `find_zero((f,fp), x0, Roots.Newton())` instead.", :newton)
+    find_zero((f, fp), x0, Newton(); kwargs...)
+end
 
 ## --------------------------------------------------
 #=
@@ -50,7 +53,10 @@ Keyword arguments are passed to `find_zero` using the `Roots.Halley()` method.
 
 """
 =#
-halley(f, fp, fpp, x0; kwargs...) = find_zero((f, fp, fpp), x0, Halley(); kwargs...)
+function halley(f, fp, fpp, x0; kwargs...)
+    Base.depwarn("`halley(f, fp, fpp,  x0)` is deprecated; use `find_zero((f,fp, fpp), x0, Roots.Halley())` instead.", :halley)
+    find_zero((f, fp, fpp), x0, Halley(); kwargs...)
+end
 
 #=
 """
@@ -76,14 +82,23 @@ Keyword arguments are passed to `find_zero` using the `Roots.QuadraticInverse()`
 
 """
 =#
-quadratic_inverse(f, fp, fpp, x0; kwargs...) =
+function quadratic_inverse(f, fp, fpp, x0; kwargs...)
+    Base.depwarn("`quadratic_inverse(f, fp, fpp,  x0)` is deprecated; use `find_zero((f,fp, fpp), x0, Roots.Quadratic_Inverse())` instead.", :quadratic_inverse)
+
     find_zero((f, fp, fpp), x0, QuadraticInverse(); kwargs...)
+end
 
-superhalley(f, fp, fpp, x0; kwargs...) =
+function superhalley(f, fp, fpp, x0; kwargs...)
+        Base.depwarn("`superhalley(f, fp, fpp,  x0)` is deprecated; use `find_zero((f,fp, fpp), x0, Roots.SuperHalley())` instead.", :superhalley)
+
     find_zero((f, fp, fpp), x0, SuperHalley(); kwargs...)
+end
 
-chebyshev_like(f, fp, fpp, x0; kwargs...) =
+function chebyshev_like(f, fp, fpp, x0; kwargs...)
+        Base.depwarn("`chebyshev_like(f, fp, fpp,  x0)` is deprecated; use `find_zero((f,fp, fpp), x0, Roots.ChebyshevLike())` instead.", :chebyshev_like)
+
     find_zero((f, fp, fpp), x0, ChebyshevLike(); kwargs...)
+end
 
 ## --------------------------------------------------
 

--- a/src/deprecated/alternative_interfaces.jl
+++ b/src/deprecated/alternative_interfaces.jl
@@ -153,6 +153,8 @@ fzero(sin, cos, 3)             # use Newton's method
 
 """
 function fzero(f, x0::Number; kwargs...)
+    Base.depwarn("`fzero(f, x0)` is deprecated; use `find_zero(f, x0)` instead.", :fzero)
+
     x = float(x0)
     isinf(x) && throw(ConvergenceFailed("An initial value must be finite"))
     derivative_free(f, x; kwargs...)
@@ -166,6 +168,8 @@ function fzero(
     tracks=NullTracks(),
     kwargs...,
 )
+    Base.depwarn("`fzero(f, x0, M)` is deprecated; use `find_zero(f, x0, M)` instead.", :fzero)
+
     tracks = (verbose && isa(tracks, NullTracks)) ? Tracks() : tracks
     α = find_zero(FnWrapper(f), x0, M; tracks, kwargs...)
     verbose && display(tracks)
@@ -181,6 +185,8 @@ function fzero(
     tracks=NullTracks(),
     kwargs...,
 )
+    Base.depwarn("`fzero(f, x0, M, N)` is deprecated; use `find_zero(f, x0, M, N)` instead.", :fzero)
+
     tracks = (verbose && isa(tracks, NullTracks)) ? Tracks() : tracks
     a = find_zero(FnWrapper(f), x0, M, N; tracks, kwargs...)
     verbose && display(tracks)
@@ -194,6 +200,9 @@ function fzero(
     tracks=NullTracks(),
     kwargs...,
 ) where {T<:Number,S<:Number}
+    Base.depwarn("`fzero(f, (a,b))` is deprecated; use `find_zero(f, (a,b))` instead.", :fzero)
+
+
     d = Dict(kwargs...)
     tracks = (verbose && isa(tracks, NullTracks)) ? Tracks() : tracks
     if haskey(d, :order)
@@ -208,6 +217,7 @@ end
 fzero(f, a::Number, b::Number, args...; kwargs...) = fzero(f, (a, b), args...; kwargs...)
 
 function fzero(f, x; verbose=false, tracks=NullTracks(), kwargs...)
+    Base.depwarn("`fzero(f, x)` is deprecated; use `find_zero(f, x)` instead.", :fzero)
     tracks = (verbose && isa(tracks, NullTracks)) ? Tracks() : tracks
     α = find_zero(FnWrapper(f), x; kwargs...)
     verbose && display(tracks)
@@ -222,6 +232,7 @@ function fzero(
     tracks=NullTracks(),
     kwargs...,
 )
+    Base.depwarn("`fzero(f, fp, x0)` is deprecated; use `find_zero((f,fp), x0)` instead.", :fzero)
     tracks = (verbose && isa(tracks, NullTracks)) ? Tracks() : tracks
     α = find_zero((f, fp), x0, Newton(); tracks, kwargs...)
     verbose && display(tracks)
@@ -303,6 +314,7 @@ Searches for all zeros of `f` within an interval `(a,b)`. Assumes neither `a` or
 Compatibility interface for [`find_zeros`](@ref).
 """
 function fzeros(f, a::Number, b::Number; kwargs...)
+    Base.depwarn("`fzeros(f, a,b)` is deprecated; use `find_zeros(f, a, b)` instead.", :fzero)
     find_zeros(FnWrapper(f), float(a), float(b); kwargs...)
 end
 fzeros(f, ab; kwargs...) = fzeros(f, _extrema(ab)...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,6 @@ include("./test_bracketing.jl")
 include("./test_derivative_free.jl")
 include("./test_simple.jl")
 include("./test_find_zeros.jl")
-include("./test_fzero.jl")
 include("./test_newton.jl")
 include("./test_chain_rules.jl")
 include("./test_simple.jl")
@@ -40,3 +39,6 @@ VERSION >= v"1.12.0" && include("./test_jet.jl")
 #include("./test_derivative_free_interactive.jl")
 
 Aqua.test_all(Roots)
+
+# deprecated
+include("./test_fzero.jl")

--- a/test/test_fzero.jl
+++ b/test/test_fzero.jl
@@ -1,6 +1,7 @@
 using Test
 import Roots.fzero
 
+## Deprecated functions
 ## Test `fzero` interface to `find_zero`
 ## test `fzeros` interface for functions
 


### PR DESCRIPTION
Add deprecation warning to fzero, fzeros and some other functions. Decide another day if those functions in simple should be deprecated. This will replace #507